### PR TITLE
RomM save-sync broker: endpoints, hardening, and a stdlib test suite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,11 @@ on:
       - main
 
 jobs:
+  ci-test:
+    uses: ./.github/workflows/ci.yml
+
   release:
+    needs: ci-test
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI Test Suite
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_call:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # The job id IS the status-check context named by the branch ruleset.
+  # Do not add a `name:` key here - it would rename the reported check and
+  # the required-check rule would block every PR waiting on "ci-test".
+  ci-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          # No `cache: pip` on purpose: setup-python hard-fails when no
+          # requirements.txt/pyproject.toml exists, and these repos have none.
+
+      - name: Install tooling
+        run: pip install pytest==8.3.4 ruff==0.15.22
+
+      - name: Run linter (ruff)
+        run: ruff check .
+
+      - name: Run unit tests (pytest)
+        run: |
+          if ls tests/test_*.py >/dev/null 2>&1; then
+            pytest tests/ -q
+          else
+            echo "::notice::no tests/ in this repo yet - ci-test is a lint-only gate"
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   # The job id IS the status-check context named by the branch ruleset.
-  # Do not add a `name:` key here - it would rename the reported check and
+  # Do not add a `name:` key here: it would rename the reported check and
   # the required-check rule would block every PR waiting on "ci-test".
   ci-test:
     runs-on: ubuntu-latest
@@ -34,9 +34,17 @@ jobs:
         run: ruff check .
 
       - name: Run unit tests (pytest)
+        env:
+          # Flip to 'true' once this repo has a suite. Without it a deleted or
+          # unstaged tests/ directory silently downgrades ci-test to a lint-only
+          # gate and still reports green, which is the failure mode this guards.
+          EXPECT_TESTS: 'true'
         run: |
           if ls tests/test_*.py >/dev/null 2>&1; then
             pytest tests/ -q
+          elif [ "$EXPECT_TESTS" = "true" ]; then
+            echo "::error::EXPECT_TESTS is set but no tests/test_*.py were found"
+            exit 1
           else
-            echo "::notice::no tests/ in this repo yet - ci-test is a lint-only gate"
+            echo "::notice::no tests/ in this repo yet, ci-test is a lint-only gate"
           fi

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -6,7 +6,11 @@ on:
       - main
 
 jobs:
+  ci-test:
+    uses: ./.github/workflows/ci.yml
+
   docker:
+    needs: ci-test
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/__pycache__/
 **/*.pyc
 **/*.pyo
+.ruff_cache/

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ streaming:
     - platform: ngc
       host: http://<dolphin-host>:3001
       label: Dolphin
+      memory_card_sync: true
     - platform: wii
       host: http://<dolphin-host>:3001
       label: Dolphin
@@ -77,9 +78,28 @@ All `POST`/`DELETE` endpoints require `X-Broker-Secret` header if `BROKER_SECRET
 | `GET` | `/state-file?slot=N` | Newest state file for slot N as raw bytes; the filename is echoed in the `X-State-Filename` header. Blocks while a save is in flight (up to `STATE_GET_WAIT`) so a GET after `/save-state` carries the finished write. `slot=0` resolves to `SAVE_SLOT`; returns `404` if the slot has no state. |
 | `PUT` | `/state-file?filename=NAME` | Write raw body into StateSaves as `NAME` (used by RomM to hydrate a claimed container). `NAME` must be a bare `<GameID>.sNN` basename; write is atomic and chowned to `abc`. Max 256 MB. |
 | `GET` | `/state-screenshot?slot=N` | PNG frame captured at the moment slot N was saved, used by RomM as the state's thumbnail. `404` if the slot has no capture. |
+| `GET` | `/save-file` | Zip of every in-game save (GC cards, Wii NAND titles) modified since the last game launch; `404` when nothing changed. |
+| `PUT` | `/save-file` | Restore a pulled save archive. Files newer in the container than in the archive are skipped. Max 256 MB. |
+| `GET` | `/memory-card` | Zip of the whole Slot-A GCI folder card, member paths relative to the card root. `404` with `X-Memory-Card: absent` when no card exists yet. |
+| `PUT` | `/memory-card` | Wipe Slot A and lay down the card in the body. Staged then swapped, so a failure never leaves a half-wiped card. Max 256 MB. |
 | `POST` | `/volume` | Set PulseAudio volume (`{"level": 80}`) |
 | `POST` | `/mute` | Mute/unmute (`{"mute": true}` or `{}` to toggle) |
 | `POST` | `/cleanup` | Restart selkies to flush stale gamepad connections |
+
+### Memory Cards
+
+Slot A is pinned to a GCI **folder** card at a fixed path (`GCIFolderAPathOverride`
+in `Dolphin.ini`), which the broker sets on every launch. Dolphin's default GCI
+folder sits under a region directory it picks from the booted game
+(`GC/USA/Card A`), which the broker cannot know before launch; the override is
+used verbatim, with no region or card-name parts appended, so there is one
+stable card directory per container.
+
+That is what lets RomM treat the card as a single per-user image: `GET
+/memory-card` evacuates it at release, `PUT /memory-card` lays the next user's
+card down at claim. Slot B is never touched. Enable it per platform in RomM
+with `memory_card_sync: true` on the `ngc` container entry (Wii saves live in
+NAND, not on a card, so the `wii` entry keeps the `/save-file` path).
 
 ### State Screenshots
 
@@ -114,6 +134,7 @@ Dolphin supports 8 save state slots. **Slot 8 is reserved exclusively for auto-s
 | `RESUME_LOAD_WAIT` | `90.0` | Max seconds a `load_slot` launch waits for the new game window before giving up on the deferred state load |
 | `RESUME_LOAD_SETTLE` | `8.0` | Seconds to let the game boot after its window appears, before the deferred `load_slot` hotkey fires |
 | `SCREENSHOT_WAIT` | `5.0` | Max seconds to wait for the screenshot hotkey to produce a PNG before giving up on the state thumbnail |
+| `GCI_CARD_DIR` | _(derived)_ | Slot-A GCI folder card path; defaults to `romm/Card A` under Dolphin's data dir |
 | `BROKER_LOG_LEVEL` | `INFO` | Logging verbosity (`DEBUG`, `INFO`, `WARNING`) |
 
 ---

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ All `POST`/`DELETE` endpoints require `X-Broker-Secret` header if `BROKER_SECRET
 |--------|------|-------------|
 | `GET` | `/health` | Returns `{"status": "ok"}` |
 | `GET` | `/status` | Current session info including slot config |
-| `POST` | `/launch` | Launch a ROM (`{"rom_path": "..."}`). Optional `"load_slot": N` (1–8) resumes from that state slot: once the new game window is up (up to `RESUME_LOAD_WAIT`, plus a `RESUME_LOAD_SETTLE` grace) the broker sends the load hotkey. Push the state file via `PUT /state-file` before launching. |
+| `POST` | `/launch` | Launch a ROM (`{"rom_path": "..."}`). Optional `"load_slot": N` (1–8) resumes from that state slot: the broker resolves the slot to its state file and passes it to Dolphin as `--save_state`, so the state is applied during boot, before emulation starts — the game is never seen running un-resumed. Returns `404` if the slot has no state file. Push the state file via `PUT /state-file` before launching. |
 | `DELETE` | `/launch` | Return to Dolphin dashboard |
 | `POST` | `/save-and-exit` | Save to auto-save slot then stop game (`{"slot": 8, "wait": true}`) |
 | `POST` | `/save-state` | Save to a user slot in background (`{"slot": 1}`) |
@@ -131,8 +131,6 @@ Dolphin supports 8 save state slots. **Slot 8 is reserved exclusively for auto-s
 | `ROM_ROOT` | `/romm/library` | ROM files must be within this path |
 | `SSTATE_WAIT` | `3.0` | Seconds to wait after save key before killing Dolphin |
 | `STATE_GET_WAIT` | `30.0` | Max seconds `GET /state-file` blocks waiting for an in-flight save to finish |
-| `RESUME_LOAD_WAIT` | `90.0` | Max seconds a `load_slot` launch waits for the new game window before giving up on the deferred state load |
-| `RESUME_LOAD_SETTLE` | `8.0` | Seconds to let the game boot after its window appears, before the deferred `load_slot` hotkey fires |
 | `SCREENSHOT_WAIT` | `5.0` | Max seconds to wait for the screenshot hotkey to produce a PNG before giving up on the state thumbnail |
 | `GCI_CARD_DIR` | _(derived)_ | Slot-A GCI folder card path; defaults to `romm/Card A` under Dolphin's data dir |
 | `BROKER_LOG_LEVEL` | `INFO` | Logging verbosity (`DEBUG`, `INFO`, `WARNING`) |

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ All `POST`/`DELETE` endpoints require `X-Broker-Secret` header if `BROKER_SECRET
 |--------|------|-------------|
 | `GET` | `/health` | Returns `{"status": "ok"}` |
 | `GET` | `/status` | Current session info including slot config |
-| `POST` | `/launch` | Launch a ROM (`{"rom_path": "..."}`). Optional `"load_slot": N` (1–8) resumes from that state slot: the broker resolves the slot to its state file and passes it to Dolphin as `--save_state`, so the state is applied during boot, before emulation starts — the game is never seen running un-resumed. Returns `404` if the slot has no state file. Push the state file via `PUT /state-file` before launching. |
+| `POST` | `/launch` | Launch a ROM (`{"rom_path": "..."}`). Optional `"load_slot": N` (`0` or omitted resolves to `SAVE_SLOT`; `1`-`8` addressable) resumes from that state slot: the broker resolves the slot to its state file and passes it to Dolphin as `--save_state`, so the state is applied during boot, before emulation starts, so the game is never seen running un-resumed. Returns `404` if the slot has no state file. Push the state file via `PUT /state-file` before launching. |
 | `DELETE` | `/launch` | Return to Dolphin dashboard |
 | `POST` | `/save-and-exit` | Save then stop game (`{"slot": N, "wait": true}`, `0` or omitted = `SAVE_SLOT`) |
 | `POST` | `/save-state` | Save state in background (`{"slot": N}`, `0` or omitted = `SAVE_SLOT`) |
@@ -78,7 +78,7 @@ All `POST`/`DELETE` endpoints require `X-Broker-Secret` header if `BROKER_SECRET
 | `GET` | `/state-file?slot=N` | Newest state file for slot N as raw bytes; the filename is echoed in the `X-State-Filename` header. Blocks while a save is in flight (up to `STATE_GET_WAIT`) so a GET after `/save-state` carries the finished write. `slot=0` resolves to `SAVE_SLOT`; returns `404` if the slot has no state. |
 | `PUT` | `/state-file?filename=NAME` | Write raw body into StateSaves as `NAME` (used by RomM to hydrate a claimed container). `NAME` must be a bare `<GameID>.sNN` basename; write is atomic and chowned to `abc`. Max 256 MB. |
 | `GET` | `/state-screenshot?slot=N` | PNG frame captured at the moment slot N was saved, used by RomM as the state's thumbnail. `404` if the slot has no capture. |
-| `GET` | `/save-file` | Zip of every in-game save (GC cards, Wii NAND titles) modified since the last game launch; `404` when nothing changed. |
+| `GET` | `/save-file` | Zip of every in-game save (GC cards, Wii NAND titles) modified since the last game launch. `404` with `X-Save-File: unchanged` when nothing changed, or `X-Save-File: absent` when no game has been launched. An untagged `404` means the endpoint is missing, not that there is nothing to sync. |
 | `PUT` | `/save-file` | Restore a pulled save archive. Files newer in the container than in the archive are skipped. Max 256 MB. |
 | `GET` | `/memory-card` | Zip of the whole Slot-A GCI folder card, member paths relative to the card root. `404` with `X-Memory-Card: absent` when no card exists yet. |
 | `PUT` | `/memory-card` | Wipe Slot A and lay down the card in the body. Staged then swapped, so a failure never leaves a half-wiped card. Max 256 MB. |
@@ -111,14 +111,14 @@ frame. It is best effort throughout: a failed capture never fails the save.
 
 ### Save State Slots
 
-Dolphin supports 8 save state slots. RomM offers no slot selection, so **all state I/O funnels through a single slot — `SAVE_SLOT` (env, default 8)**, the same shape the pcsx2 broker uses. Splitting manual saves and auto-saves across two slots would only split the library's view of a session across two files.
+Dolphin supports 8 save state slots. RomM offers no slot selection, so **all state I/O funnels through a single slot, `SAVE_SLOT` (env, default 8)**, the same shape the pcsx2 broker uses. Splitting manual saves and auto-saves across two slots would only split the library's view of a session across two files.
 
 | Action | Slot | Hotkey |
 |--------|------|--------|
-| Save | `SAVE_SLOT` (`0` or omitted resolves to it; `1`–`8` addressable) | `Shift+F1` – `Shift+F8` |
-| Load | `SAVE_SLOT` (`0` or omitted resolves to it; `1`–`8` addressable) | `F1` – `F8` |
+| Save | `SAVE_SLOT` (`0` or omitted resolves to it; `1`-`8` addressable) | `Shift+F1` - `Shift+F8` |
+| Load | `SAVE_SLOT` (`0` or omitted resolves to it; `1`-`8` addressable) | `F1` - `F8` |
 
-`SAVE_SLOT` is written by manual saves, by save-and-exit, and automatically whenever you navigate away from a game (switch titles or click save-and-exit); every read defaults to it. The explicit `1`–`8` range stays addressable for debugging.
+`SAVE_SLOT` is written by manual saves, by save-and-exit, and automatically whenever you navigate away from a game (switch titles or click save-and-exit); every read defaults to it. The explicit `1`-`8` range stays addressable for debugging.
 
 ---
 
@@ -129,9 +129,10 @@ Dolphin supports 8 save state slots. RomM offers no slot selection, so **all sta
 | `BROKER_PORT` | `8000` | HTTP port the broker listens on |
 | `BROKER_SECRET` | _(empty)_ | Shared secret for request auth (`X-Broker-Secret` header) |
 | `ROM_ROOT` | `/romm/library` | ROM files must be within this path |
-| `SAVE_SLOT` | `8` | The one slot every state save and load uses (1–8) |
+| `SAVE_SLOT` | `8` | The one slot every state save and load uses (1-8) |
 | `SSTATE_WAIT` | `3.0` | Seconds to wait after save key before killing Dolphin |
 | `STATE_GET_WAIT` | `30.0` | Max seconds `GET /state-file` blocks waiting for an in-flight save to finish |
+| `DISPLAY_WAIT` | `30.0` | Max seconds to wait for the X server socket before starting anyway |
 | `SCREENSHOT_WAIT` | `5.0` | Max seconds to wait for the screenshot hotkey to produce a PNG before giving up on the state thumbnail |
 | `GCI_CARD_DIR` | _(derived)_ | Slot-A GCI folder card path; defaults to `romm/Card A` under Dolphin's data dir |
 | `BROKER_LOG_LEVEL` | `INFO` | Logging verbosity (`DEBUG`, `INFO`, `WARNING`) |
@@ -140,7 +141,7 @@ Dolphin supports 8 save state slots. RomM offers no slot selection, so **all sta
 
 ## Controller Setup
 
-The mod uses the [selkies joystick interposer](https://github.com/selkies-project/selkies-gstreamer) to forward browser gamepad input into the container as virtual Xbox 360 pads (`SDL/0–3/Microsoft X-Box 360 pad`).
+The mod uses the [selkies joystick interposer](https://github.com/selkies-project/selkies-gstreamer) to forward browser gamepad input into the container as virtual Xbox 360 pads (`SDL/0-3/Microsoft X-Box 360 pad`).
 
 ### Default mapping
 
@@ -161,7 +162,7 @@ The file is at `<your-config-volume>/.config/dolphin-emu/GCPadNew.ini`. Restart 
 
 ### Persisting controller config
 
-Controller mapping and calibration are stored in the `/config` volume and survive game switches. Dolphin does **not** auto-save controller settings on exit — you must click the **Close** button (not just OK) in Dolphin's controller settings dialog to write changes to disk.
+Controller mapping and calibration are stored in the `/config` volume and survive game switches. Dolphin does **not** auto-save controller settings on exit: you must click the **Close** button (not just OK) in Dolphin's controller settings dialog to write changes to disk.
 
 ---
 
@@ -198,10 +199,10 @@ The broker controls PulseAudio sink volume for the `abc` user. Verify PulseAudio
 **Controller input stops working after game switch**
 This is prevented by `BackgroundInput = True` in `Dolphin.ini` (set automatically by the broker). If input drops, check the broker log for socket cleanup warnings.
 
-**Nothing reaches Dolphin — neither broker hotkeys nor browser gamepad**
+**Nothing reaches Dolphin, neither broker hotkeys nor browser gamepad**
 Both transports die together when Dolphin's global input gate shuts, so treat
 simultaneous failure as one bug, not two. The gate is fed by two settings whose
-Dolphin sections differ and whose defaults both demand render-window focus —
+Dolphin sections differ and whose defaults both demand render-window focus,
 focus the window never gets, since Dolphin is an Xwayland client under labwc:
 
 | Setting | Section | Default | Broker sets |

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # dolphin-romm-integration-mod
 
-A [linuxserver Docker mod](https://www.linuxserver.io/blog/2019-09-14-customizing-our-containers) for [linuxserver/dolphin](https://docs.linuxserver.io/images/docker-dolphin/) that integrates [RomM](https://github.com/rommapp/romm) streaming support.
+A [linuxserver Docker mod](https://www.linuxserver.io/blog/2019-09-14-customizing-our-containers) for [linuxserver/dolphin](https://docs.linuxserver.io/images/docker-dolphin/) that adds [RomM](https://github.com/rommapp/romm) streaming support.
 
-The mod injects a lightweight HTTP broker that manages the Dolphin emulator lifecycle — launching games on demand, saving/loading state, controlling volume, and streaming the display back to the RomM player page via the container's built-in WebRTC stream.
+An HTTP broker runs inside the container and manages the Dolphin lifecycle: game launches, save/load state, volume control, and returning to dashboard when a session ends. The display streams back to the RomM player via the container's built-in WebRTC/selkies setup.
 
 ---
 
@@ -55,9 +55,6 @@ streaming:
       host: http://<dolphin-host>:3001
       label: Dolphin
     - platform: wii
-      host: http://<dolphin-host>:3001
-      label: Dolphin
-    - platform: wiiu
       host: http://<dolphin-host>:3001
       label: Dolphin
 ```

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ All `POST`/`DELETE` endpoints require `X-Broker-Secret` header if `BROKER_SECRET
 | `DELETE` | `/launch` | Return to Dolphin dashboard |
 | `POST` | `/save-and-exit` | Save then stop game (`{"slot": N, "wait": true}`, `0` or omitted = `SAVE_SLOT`) |
 | `POST` | `/save-state` | Save state in background (`{"slot": N}`, `0` or omitted = `SAVE_SLOT`) |
-| `POST` | `/load-state` | Load a state (`{"slot": N}`, `0` or omitted = `SAVE_SLOT`) |
-| `GET` | `/state-file?slot=N` | Newest state file for slot N as raw bytes; the filename is echoed in the `X-State-Filename` header. Blocks while a save is in flight (up to `STATE_GET_WAIT`) so a GET after `/save-state` carries the finished write. `slot=0` resolves to `SAVE_SLOT`; returns `404` if the slot has no state. |
-| `PUT` | `/state-file?filename=NAME` | Write raw body into StateSaves as `NAME` (used by RomM to hydrate a claimed container). `NAME` must be a bare `<GameID>.sNN` basename; write is atomic and chowned to `abc`. Max 256 MB. |
-| `GET` | `/state-screenshot?slot=N` | PNG frame captured at the moment slot N was saved, used by RomM as the state's thumbnail. `404` if the slot has no capture. |
+| `POST` | `/load-state` | Load a state (`{"slot": N}`, `0` or omitted = `SAVE_SLOT`). `409` while a save is in flight, so a load never races the write it would overwrite. |
+| `GET` | `/state-file?slot=N` | Newest state file for slot N as raw bytes; the filename is echoed in the `X-State-Filename` header. Blocks while a save is in flight (up to `STATE_GET_WAIT`) so a GET after `/save-state` carries the finished write. `slot=0` resolves to `SAVE_SLOT`; returns `404` if the slot has no state, and `409` if the save is still running when `STATE_GET_WAIT` expires (the file on disk is mid-flush and must not be stored as the state). |
+| `PUT` | `/state-file?filename=NAME` | Write raw body into StateSaves as `NAME` (used by RomM to hydrate a claimed container). `NAME` must be a bare `<GameID>.sNN` basename with `NN` in `01`-`08`; write is atomic and chowned to `abc`. Max 256 MB. |
+| `GET` | `/state-screenshot?slot=N` | PNG frame captured at the moment slot N was saved, used by RomM as the state's thumbnail. `404` if the slot has no capture, `409` if a save is still in flight after `STATE_GET_WAIT`. |
 | `GET` | `/save-file` | Zip of every in-game save (GC cards, Wii NAND titles) modified since the last game launch. `404` with `X-Save-File: unchanged` when nothing changed, or `X-Save-File: absent` when no game has been launched. An untagged `404` means the endpoint is missing, not that there is nothing to sync. |
 | `PUT` | `/save-file` | Restore a pulled save archive. Files newer in the container than in the archive are skipped. Max 256 MB. |
 | `GET` | `/memory-card` | Zip of the whole Slot-A GCI folder card, member paths relative to the card root. `404` with `X-Memory-Card: absent` when no card exists yet. |
@@ -132,6 +132,7 @@ Dolphin supports 8 save state slots. RomM offers no slot selection, so **all sta
 | `SAVE_SLOT` | `8` | The one slot every state save and load uses (1-8) |
 | `SSTATE_WAIT` | `3.0` | Seconds to wait after save key before killing Dolphin |
 | `STATE_GET_WAIT` | `30.0` | Max seconds `GET /state-file` blocks waiting for an in-flight save to finish |
+| `BROKER_SPOOL_DIR` | `/config/.romm-broker-spool` | Where uploads are spooled to disk; falls back to the system temp dir if it cannot be created |
 | `DISPLAY_WAIT` | `30.0` | Max seconds to wait for the X server socket before starting anyway |
 | `SCREENSHOT_WAIT` | `5.0` | Max seconds to wait for the screenshot hotkey to produce a PNG before giving up on the state thumbnail |
 | `GCI_CARD_DIR` | _(derived)_ | Slot-A GCI folder card path; defaults to `romm/Card A` under Dolphin's data dir |

--- a/README.md
+++ b/README.md
@@ -76,9 +76,18 @@ All `POST`/`DELETE` endpoints require `X-Broker-Secret` header if `BROKER_SECRET
 | `POST` | `/load-state` | Load from a slot (`{"slot": 1}`) |
 | `GET` | `/state-file?slot=N` | Newest state file for slot N as raw bytes; the filename is echoed in the `X-State-Filename` header. Blocks while a save is in flight (up to `STATE_GET_WAIT`) so a GET after `/save-state` carries the finished write. `slot=0` resolves to `SAVE_SLOT`; returns `404` if the slot has no state. |
 | `PUT` | `/state-file?filename=NAME` | Write raw body into StateSaves as `NAME` (used by RomM to hydrate a claimed container). `NAME` must be a bare `<GameID>.sNN` basename; write is atomic and chowned to `abc`. Max 256 MB. |
+| `GET` | `/state-screenshot?slot=N` | PNG frame captured at the moment slot N was saved, used by RomM as the state's thumbnail. `404` if the slot has no capture. |
 | `POST` | `/volume` | Set PulseAudio volume (`{"level": 80}`) |
 | `POST` | `/mute` | Mute/unmute (`{"mute": true}` or `{}` to toggle) |
 | `POST` | `/cleanup` | Restart selkies to flush stale gamepad connections |
+
+### State Screenshots
+
+Dolphin savestates carry no embedded frame, so the broker takes one: the
+screenshot hotkey (`F9`) fires just before the save key and the PNG Dolphin
+writes to `ScreenShots` is filed under the slot for `GET /state-screenshot`.
+Firing before the save keeps the "Saved State to Slot N" banner out of the
+frame. It is best effort throughout: a failed capture never fails the save.
 
 ### Save State Slots
 
@@ -104,6 +113,7 @@ Dolphin supports 8 save state slots. **Slot 8 is reserved exclusively for auto-s
 | `STATE_GET_WAIT` | `30.0` | Max seconds `GET /state-file` blocks waiting for an in-flight save to finish |
 | `RESUME_LOAD_WAIT` | `90.0` | Max seconds a `load_slot` launch waits for the new game window before giving up on the deferred state load |
 | `RESUME_LOAD_SETTLE` | `8.0` | Seconds to let the game boot after its window appears, before the deferred `load_slot` hotkey fires |
+| `SCREENSHOT_WAIT` | `5.0` | Max seconds to wait for the screenshot hotkey to produce a PNG before giving up on the state thumbnail |
 | `BROKER_LOG_LEVEL` | `INFO` | Logging verbosity (`DEBUG`, `INFO`, `WARNING`) |
 
 ---

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ All `POST`/`DELETE` endpoints require `X-Broker-Secret` header if `BROKER_SECRET
 |--------|------|-------------|
 | `GET` | `/health` | Returns `{"status": "ok"}` |
 | `GET` | `/status` | Current session info including slot config |
-| `POST` | `/launch` | Launch a ROM (`{"rom_path": "..."}`) |
+| `POST` | `/launch` | Launch a ROM (`{"rom_path": "..."}`). Optional `"load_slot": N` (1–8) resumes from that state slot: once the new game window is up (up to `RESUME_LOAD_WAIT`, plus a `RESUME_LOAD_SETTLE` grace) the broker sends the load hotkey. Push the state file via `PUT /state-file` before launching. |
 | `DELETE` | `/launch` | Return to Dolphin dashboard |
 | `POST` | `/save-and-exit` | Save to auto-save slot then stop game (`{"slot": 8, "wait": true}`) |
 | `POST` | `/save-state` | Save to a user slot in background (`{"slot": 1}`) |
@@ -102,6 +102,8 @@ Dolphin supports 8 save state slots. **Slot 8 is reserved exclusively for auto-s
 | `ROM_ROOT` | `/romm/library` | ROM files must be within this path |
 | `SSTATE_WAIT` | `3.0` | Seconds to wait after save key before killing Dolphin |
 | `STATE_GET_WAIT` | `30.0` | Max seconds `GET /state-file` blocks waiting for an in-flight save to finish |
+| `RESUME_LOAD_WAIT` | `90.0` | Max seconds a `load_slot` launch waits for the new game window before giving up on the deferred state load |
+| `RESUME_LOAD_SETTLE` | `8.0` | Seconds to let the game boot after its window appears, before the deferred `load_slot` hotkey fires |
 | `BROKER_LOG_LEVEL` | `INFO` | Logging verbosity (`DEBUG`, `INFO`, `WARNING`) |
 
 ---

--- a/README.md
+++ b/README.md
@@ -198,3 +198,18 @@ The broker controls PulseAudio sink volume for the `abc` user. Verify PulseAudio
 
 **Controller input stops working after game switch**
 This is prevented by `BackgroundInput = True` in `Dolphin.ini` (set automatically by the broker). If input drops, check the broker log for socket cleanup warnings.
+
+**Nothing reaches Dolphin — neither broker hotkeys nor browser gamepad**
+Both transports die together when Dolphin's global input gate shuts, so treat
+simultaneous failure as one bug, not two. The gate is fed by two settings whose
+Dolphin sections differ and whose defaults both demand render-window focus —
+focus the window never gets, since Dolphin is an Xwayland client under labwc:
+
+| Setting | Section | Default | Broker sets |
+|---|---|---|---|
+| `HotkeysRequireFocus` | `[General]` | `True` | `False` |
+| `BackgroundInput` | `[Input]` | `False` | `True` |
+
+Note `BackgroundInput` lives under `[Input]`, **not** `[General]`. Placed in the
+wrong section it is silently ignored and the gate stays shut. Verify with
+`grep -A1 '\[Input\]' Dolphin.ini`; the emulator must be restarted to reload it.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ All `POST`/`DELETE` endpoints require `X-Broker-Secret` header if `BROKER_SECRET
 | `POST` | `/save-and-exit` | Save to auto-save slot then stop game (`{"slot": 8, "wait": true}`) |
 | `POST` | `/save-state` | Save to a user slot in background (`{"slot": 1}`) |
 | `POST` | `/load-state` | Load from a slot (`{"slot": 1}`) |
+| `GET` | `/state-file?slot=N` | Newest state file for slot N as raw bytes; the filename is echoed in the `X-State-Filename` header. Blocks while a save is in flight (up to `STATE_GET_WAIT`) so a GET after `/save-state` carries the finished write. `slot=0` resolves to `SAVE_SLOT`; returns `404` if the slot has no state. |
+| `PUT` | `/state-file?filename=NAME` | Write raw body into StateSaves as `NAME` (used by RomM to hydrate a claimed container). `NAME` must be a bare `<GameID>.sNN` basename; write is atomic and chowned to `abc`. Max 256 MB. |
 | `POST` | `/volume` | Set PulseAudio volume (`{"level": 80}`) |
 | `POST` | `/mute` | Mute/unmute (`{"mute": true}` or `{}` to toggle) |
 | `POST` | `/cleanup` | Restart selkies to flush stale gamepad connections |
@@ -99,6 +101,7 @@ Dolphin supports 8 save state slots. **Slot 8 is reserved exclusively for auto-s
 | `BROKER_SECRET` | _(empty)_ | Shared secret for request auth (`X-Broker-Secret` header) |
 | `ROM_ROOT` | `/romm/library` | ROM files must be within this path |
 | `SSTATE_WAIT` | `3.0` | Seconds to wait after save key before killing Dolphin |
+| `STATE_GET_WAIT` | `30.0` | Max seconds `GET /state-file` blocks waiting for an in-flight save to finish |
 | `BROKER_LOG_LEVEL` | `INFO` | Logging verbosity (`DEBUG`, `INFO`, `WARNING`) |
 
 ---

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An S6 service (`svc-broker`) runs `broker.py` as root inside the container. The 
 
 1. Kills any stale Dolphin process on startup, then launches Dolphin in dashboard mode.
 2. Accepts HTTP requests from the RomM backend to launch ROMs, save/load state, set volume, and stop sessions.
-3. Auto-saves to the reserved auto-save slot whenever a game is exited or switched.
+3. Auto-saves to `SAVE_SLOT` whenever a game is exited or switched.
 4. Monitors the Dolphin process and relaunches it into dashboard mode if it exits unexpectedly.
 
 ---
@@ -72,9 +72,9 @@ All `POST`/`DELETE` endpoints require `X-Broker-Secret` header if `BROKER_SECRET
 | `GET` | `/status` | Current session info including slot config |
 | `POST` | `/launch` | Launch a ROM (`{"rom_path": "..."}`). Optional `"load_slot": N` (1–8) resumes from that state slot: the broker resolves the slot to its state file and passes it to Dolphin as `--save_state`, so the state is applied during boot, before emulation starts — the game is never seen running un-resumed. Returns `404` if the slot has no state file. Push the state file via `PUT /state-file` before launching. |
 | `DELETE` | `/launch` | Return to Dolphin dashboard |
-| `POST` | `/save-and-exit` | Save to auto-save slot then stop game (`{"slot": 8, "wait": true}`) |
-| `POST` | `/save-state` | Save to a user slot in background (`{"slot": 1}`) |
-| `POST` | `/load-state` | Load from a slot (`{"slot": 1}`) |
+| `POST` | `/save-and-exit` | Save then stop game (`{"slot": N, "wait": true}`, `0` or omitted = `SAVE_SLOT`) |
+| `POST` | `/save-state` | Save state in background (`{"slot": N}`, `0` or omitted = `SAVE_SLOT`) |
+| `POST` | `/load-state` | Load a state (`{"slot": N}`, `0` or omitted = `SAVE_SLOT`) |
 | `GET` | `/state-file?slot=N` | Newest state file for slot N as raw bytes; the filename is echoed in the `X-State-Filename` header. Blocks while a save is in flight (up to `STATE_GET_WAIT`) so a GET after `/save-state` carries the finished write. `slot=0` resolves to `SAVE_SLOT`; returns `404` if the slot has no state. |
 | `PUT` | `/state-file?filename=NAME` | Write raw body into StateSaves as `NAME` (used by RomM to hydrate a claimed container). `NAME` must be a bare `<GameID>.sNN` basename; write is atomic and chowned to `abc`. Max 256 MB. |
 | `GET` | `/state-screenshot?slot=N` | PNG frame captured at the moment slot N was saved, used by RomM as the state's thumbnail. `404` if the slot has no capture. |
@@ -111,14 +111,14 @@ frame. It is best effort throughout: a failed capture never fails the save.
 
 ### Save State Slots
 
-Dolphin supports 8 save state slots. **Slot 8 is reserved exclusively for auto-saves** and is not shown in the RomM slot selector.
+Dolphin supports 8 save state slots. RomM offers no slot selection, so **all state I/O funnels through a single slot — `SAVE_SLOT` (env, default 8)**, the same shape the pcsx2 broker uses. Splitting manual saves and auto-saves across two slots would only split the library's view of a session across two files.
 
-| Action | User slots | Auto-save slot | Hotkey |
-|--------|-----------|---------------|--------|
-| Save | 1–7 | 8 (auto only) | `Shift+F1` – `Shift+F8` |
-| Load | 1–7 | 8 (load autosave button) | `F1` – `F8` |
+| Action | Slot | Hotkey |
+|--------|------|--------|
+| Save | `SAVE_SLOT` (`0` or omitted resolves to it; `1`–`8` addressable) | `Shift+F1` – `Shift+F8` |
+| Load | `SAVE_SLOT` (`0` or omitted resolves to it; `1`–`8` addressable) | `F1` – `F8` |
 
-**Auto-save behaviour:** slot 8 is written automatically whenever you navigate away from a game (switch titles or click save-and-exit). The "load autosave" button in the RomM player always loads slot 8.
+`SAVE_SLOT` is written by manual saves, by save-and-exit, and automatically whenever you navigate away from a game (switch titles or click save-and-exit); every read defaults to it. The explicit `1`–`8` range stays addressable for debugging.
 
 ---
 
@@ -129,6 +129,7 @@ Dolphin supports 8 save state slots. **Slot 8 is reserved exclusively for auto-s
 | `BROKER_PORT` | `8000` | HTTP port the broker listens on |
 | `BROKER_SECRET` | _(empty)_ | Shared secret for request auth (`X-Broker-Secret` header) |
 | `ROM_ROOT` | `/romm/library` | ROM files must be within this path |
+| `SAVE_SLOT` | `8` | The one slot every state save and load uses (1–8) |
 | `SSTATE_WAIT` | `3.0` | Seconds to wait after save key before killing Dolphin |
 | `STATE_GET_WAIT` | `30.0` | Max seconds `GET /state-file` blocks waiting for an in-flight save to finish |
 | `SCREENSHOT_WAIT` | `5.0` | Max seconds to wait for the screenshot hotkey to produce a PNG before giving up on the state thumbnail |

--- a/root/defaults/WiimoteNew.ini
+++ b/root/defaults/WiimoteNew.ini
@@ -1,0 +1,40 @@
+[Wiimote1]
+Device = SDL/0/Microsoft X-Box 360 pad
+Source = 1
+Extension = Nunchuk
+Buttons/A = `Button S`
+Buttons/B = `Trigger R`
+Buttons/1 = `Button W`
+Buttons/2 = `Button N`
+Buttons/- = Back
+Buttons/+ = Start
+Buttons/Home = `Thumb L`
+D-Pad/Up = `Pad N`
+D-Pad/Down = `Pad S`
+D-Pad/Left = `Pad W`
+D-Pad/Right = `Pad E`
+IR/Up = `Right Y+`
+IR/Down = `Right Y-`
+IR/Left = `Right X-`
+IR/Right = `Right X+`
+Shake/X = `Button E`
+Shake/Y = `Button E`
+Shake/Z = `Button E`
+Nunchuk/Buttons/C = `Shoulder L`
+Nunchuk/Buttons/Z = `Trigger L`
+Nunchuk/Stick/Up = `Left Y+`
+Nunchuk/Stick/Down = `Left Y-`
+Nunchuk/Stick/Left = `Left X-`
+Nunchuk/Stick/Right = `Left X+`
+Nunchuk/Stick/Calibration = 100.00 141.42 100.00 141.42 100.00 141.42 100.00 141.42
+Nunchuk/Shake/X = `Shoulder R`
+Nunchuk/Shake/Y = `Shoulder R`
+Nunchuk/Shake/Z = `Shoulder R`
+[Wiimote2]
+Source = 0
+[Wiimote3]
+Source = 0
+[Wiimote4]
+Source = 0
+[BalanceBoard]
+Source = 0

--- a/root/etc/s6-overlay/s6-rc.d/init-dolphin-config/init.sh
+++ b/root/etc/s6-overlay/s6-rc.d/init-dolphin-config/init.sh
@@ -93,9 +93,14 @@ if [ -f "$INPUT_HANDLER" ]; then
     if ! grep -q "reader.at_eof()" "$INPUT_HANDLER"; then
         sed -i \
             's/while self\.running and not writer\.is_closing():/while self.running and not writer.is_closing() and not reader.at_eof():/' \
-            "$INPUT_HANDLER" \
-            || echo "[broker-mod] ERROR: sed patch failed on input_handler.py"
-        echo "[broker-mod] Patched selkies input_handler.py EOF detection."
+            "$INPUT_HANDLER"
+        # Verify the substitution actually took — sed exits 0 even when the
+        # pattern never matched, so grep is the only honest success signal.
+        if grep -q "reader.at_eof()" "$INPUT_HANDLER"; then
+            echo "[broker-mod] Patched selkies input_handler.py EOF detection."
+        else
+            echo "[broker-mod] ERROR: input_handler.py EOF pattern not found — patch NOT applied (upstream may have changed)"
+        fi
     fi
 
     # Silence the selkies_gamepad logger — it emits ~80 INFO lines per launch cycle.

--- a/root/etc/s6-overlay/s6-rc.d/init-dolphin-config/init.sh
+++ b/root/etc/s6-overlay/s6-rc.d/init-dolphin-config/init.sh
@@ -15,50 +15,22 @@ chmod 0440 /etc/sudoers.d/broker
 echo "[broker-mod] sudoers rule set."
 
 # Disable the labwc autostart so dolphin-emu isn't launched a second time by
-# the desktop session — the broker manages the process lifecycle directly.
+# the desktop session: the broker manages the process lifecycle directly.
 AUTOSTART="/config/.config/labwc/autostart"
 mkdir -p "$(dirname "$AUTOSTART")"
 printf '# Disabled by dolphin-broker-mod\n' > "$AUTOSTART"
 echo "[broker-mod] Disabled labwc autostart."
 
 # Dolphin on this image stores all config files directly in
-# ~/.config/dolphin-emu/ — there is no Config/ subdirectory.
+# ~/.config/dolphin-emu/. There is no Config/ subdirectory. Dolphin.ini itself
+# is not seeded here: broker.py writes it on startup, before Dolphin launches,
+# and a second copy of those defaults drifts out of sync with the broker's.
 DOLPHIN_CFG_DIR="/config/.config/dolphin-emu"
 mkdir -p "$DOLPHIN_CFG_DIR"
 
-# Pre-seed Dolphin.ini so the broker's INI patch has something to work with
-# on the very first launch, before Dolphin has written its own copy.
-DOLPHIN_INI="$DOLPHIN_CFG_DIR/Dolphin.ini"
-if [ ! -f "$DOLPHIN_INI" ]; then
-    cat > "$DOLPHIN_INI" <<'EOF'
-[General]
-BackgroundInput = True
-
-[Core]
-SIDevice0 = 6
-SIDevice1 = 0
-SIDevice2 = 0
-SIDevice3 = 0
-GFXBackend = OpenGL
-CPUThread = False
-
-[Interface]
-ConfirmStop = False
-
-[Display]
-RenderToMain = False
-Fullscreen = False
-
-[Analytics]
-Enabled = False
-PermissionAsked = True
-EOF
-    echo "[broker-mod] Created default Dolphin.ini."
-fi
-
 # Copy default controller profile if not already present.  The container ships
 # a ready-made GCPadNew.ini in /defaults/ that maps all 4 GCPad ports to
-# SDL "Microsoft X-Box 360 pad" — exactly what the selkies joystick interposer
+# SDL "Microsoft X-Box 360 pad", exactly what the selkies joystick interposer
 # presents.  Without this file Dolphin has no controller mappings configured.
 GCPAD_INI="$DOLPHIN_CFG_DIR/GCPadNew.ini"
 if [ ! -f "$GCPAD_INI" ] && [ -f "/defaults/GCPadNew.ini" ]; then
@@ -83,7 +55,7 @@ fi
 
 # Log kernel input device names so we can verify GCPadNew.ini uses the right
 # SDL device name.  Without libudev.so.1.0.0-fake, SDL falls back to sysfs for
-# device names — these are the names it will see.
+# device names. These are the names it will see.
 if [ "${BROKER_LOG_LEVEL,,}" = "debug" ]; then
     echo "[broker-mod] Input device names (for GCPadNew.ini SDL mapping):"
     for node in js0 js1 js2 js3; do
@@ -99,7 +71,7 @@ fi
 # Patch the selkies input_handler.py keep-alive loop to check reader.at_eof().
 # Without this, idle gamepad sockets never detect client disconnection because
 # asyncio buffers the EOF but writer.is_closing() never flips on Unix sockets.
-# Locate selkies input_handler.py — glob over the python version so the patch
+# Locate selkies input_handler.py, globbing over the python version so the patch
 # survives base image upgrades that bump e.g. python3.12 → python3.13.
 INPUT_HANDLER=$(compgen -G "/lsiopy/lib/python3.*/site-packages/selkies/input_handler.py" | head -1)
 INPUT_HANDLER="${INPUT_HANDLER:-/lsiopy/lib/python3.13/site-packages/selkies/input_handler.py}"
@@ -109,16 +81,16 @@ if [ -f "$INPUT_HANDLER" ]; then
         sed -i \
             's/while self\.running and not writer\.is_closing():/while self.running and not writer.is_closing() and not reader.at_eof():/' \
             "$INPUT_HANDLER"
-        # Verify the substitution actually took — sed exits 0 even when the
+        # Verify the substitution actually took: sed exits 0 even when the
         # pattern never matched, so grep is the only honest success signal.
         if grep -q "reader.at_eof()" "$INPUT_HANDLER"; then
             echo "[broker-mod] Patched selkies input_handler.py EOF detection."
         else
-            echo "[broker-mod] ERROR: input_handler.py EOF pattern not found — patch NOT applied (upstream may have changed)"
+            echo "[broker-mod] ERROR: input_handler.py EOF pattern not found, patch NOT applied (upstream may have changed)"
         fi
     fi
 
-    # Silence the selkies_gamepad logger — it emits ~80 INFO lines per launch cycle.
+    # Silence the selkies_gamepad logger: it emits ~80 INFO lines per launch cycle.
     # Uses python3 for the insertion because sed \n behaviour is not portable across
     # GNU/BSD sed variants and can silently produce a literal '\n' in the file.
     if ! grep -q "setLevel(logging.WARNING)" "$INPUT_HANDLER"; then

--- a/root/etc/s6-overlay/s6-rc.d/init-dolphin-config/init.sh
+++ b/root/etc/s6-overlay/s6-rc.d/init-dolphin-config/init.sh
@@ -66,6 +66,21 @@ if [ ! -f "$GCPAD_INI" ] && [ -f "/defaults/GCPadNew.ini" ]; then
     echo "[broker-mod] Copied default GCPadNew.ini (controller mappings)."
 fi
 
+# Seed the emulated Wiimote profile for Wii titles.  The base image ships no
+# WiimoteNew.ini, so Dolphin auto-generates a mouse/keyboard profile that is
+# useless over a stream.  This mod's /defaults/WiimoteNew.ini maps an emulated
+# Wiimote+Nunchuk to the SDL pad: Nunchuk stick on left stick, IR pointer on
+# right stick, Wiimote shake on B, Nunchuk shake on RB.  Replace the existing
+# file only while it has never been pointed at an SDL device, so a hand-tuned
+# profile survives restarts.
+WIIMOTE_INI="$DOLPHIN_CFG_DIR/WiimoteNew.ini"
+if [ -f "/defaults/WiimoteNew.ini" ]; then
+    if [ ! -f "$WIIMOTE_INI" ] || ! grep -q "Device = SDL/" "$WIIMOTE_INI"; then
+        cp /defaults/WiimoteNew.ini "$WIIMOTE_INI"
+        echo "[broker-mod] Seeded WiimoteNew.ini (emulated Wiimote+Nunchuk on SDL pad)."
+    fi
+fi
+
 # Log kernel input device names so we can verify GCPadNew.ini uses the right
 # SDL device name.  Without libudev.so.1.0.0-fake, SDL falls back to sysfs for
 # device names — these are the names it will see.

--- a/root/etc/s6-overlay/s6-rc.d/svc-broker/finish
+++ b/root/etc/s6-overlay/s6-rc.d/svc-broker/finish
@@ -1,2 +1,2 @@
 #!/usr/bin/with-contenv bash
-echo "[broker-mod] broker.py exited with code $1 — s6 will restart it"
+echo "[broker-mod] broker.py exited with code $1, s6 will restart it"

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -122,6 +122,19 @@ def _validate_rom_path(raw: str) -> Path | None:
     return p
 
 
+def _chown_abc(path: Path):
+    """Hand a broker-written file back to abc.
+
+    The broker runs as root, so anything it writes lands root-owned and
+    Dolphin (running as abc) can read but never rewrite it — every setting
+    Dolphin tries to persist is then silently dropped.
+    """
+    try:
+        os.chown(path, _LOG_UID, _LOG_GID)
+    except OSError as exc:
+        log.warning("Could not chown %s to %d:%d: %s", path, _LOG_UID, _LOG_GID, exc)
+
+
 def _patch_ini(fullscreen: bool = False):
     """Patch Dolphin.ini to set required broker defaults.
 
@@ -142,6 +155,9 @@ def _patch_ini(fullscreen: bool = False):
         try:
             INI_PATH.write_text(
                 "[General]\n"
+                "HotkeysRequireFocus = False\n"
+                "\n"
+                "[Input]\n"
                 "BackgroundInput = True\n"
                 "\n"
                 "[Core]\n"
@@ -169,11 +185,27 @@ def _patch_ini(fullscreen: bool = False):
             log.error("Could not create %s: %s — broker defaults not applied",
                       INI_PATH, exc)
             return
+        _chown_abc(INI_PATH)
         log.info("Created Dolphin.ini with broker defaults (fullscreen=%s)", fullscreen)
         return
 
+    # Both keys below feed Core::UpdateInputGate, which drives the single
+    # global ControlReference input gate. When that gate is shut every
+    # ControlReference reads 0 — hotkeys, GC pads and Wiimotes alike — so a
+    # wrong value here kills xdotool and browser gamepad input together.
+    #
+    # Section names are Dolphin's, not ours, and the two differ:
+    #   MAIN_FOCUSED_HOTKEYS        [General] HotkeysRequireFocus  default True
+    #   MAIN_INPUT_BACKGROUND_INPUT [Input]   BackgroundInput      default False
+    # Both defaults require the render window to hold focus, which it never
+    # does: Dolphin is an Xwayland client under labwc and the surface is not
+    # given keyboard focus. BackgroundInput lived under [General] until
+    # 2026-07-20, where Dolphin never read it.
     target = {
         "General": {
+            "HotkeysRequireFocus": "False",
+        },
+        "Input": {
             "BackgroundInput": "True",
         },
         "Core": {
@@ -241,6 +273,7 @@ def _patch_ini(fullscreen: bool = False):
         tmp = INI_PATH.with_suffix(".tmp")
         tmp.write_text("\n".join(new_lines) + "\n")
         tmp.replace(INI_PATH)
+        _chown_abc(INI_PATH)
         log.debug("Dolphin.ini patched (ConfirmStop)")
     except Exception as exc:
         log.error("Failed to patch Dolphin.ini: %s", exc)

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -29,6 +29,11 @@ if not (1 <= SAVE_SLOT <= 7):
 # Returns as soon as the file size is stable, so raising this only affects the
 # failure path. Falls back to a fixed 3 s sleep if the StateSaves dir is absent.
 SSTATE_WAIT   = float(os.environ.get("SSTATE_WAIT", "10.0"))
+# Resume-from-state (launch with load_slot): how long to wait for the game
+# window to appear, and how long to let the game settle before the deferred
+# slot load. Dolphin has no IPC status probe, so the settle is generous.
+RESUME_LOAD_WAIT   = float(os.environ.get("RESUME_LOAD_WAIT",   "90.0"))
+RESUME_LOAD_SETTLE = float(os.environ.get("RESUME_LOAD_SETTLE", "8.0"))
 
 # Dolphin writes savestates to StateSaves under its data dir; the location
 # varies by build (XDG vs. non-XDG layout), so both are probed at save time.
@@ -89,6 +94,9 @@ _session: dict = {
     "started_at":       None,
     "is_managed":       False,
     "save_in_progress": False,
+    # True from POST /launch until _launch_dolphin has swapped instances —
+    # gates the deferred resume load so it never fires at the old window.
+    "launch_in_progress": False,
 }
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -387,6 +395,14 @@ def _cleanup_stale_sockets():
 
 
 def _launch_dolphin(rom_path):
+    try:
+        _launch_dolphin_inner(rom_path)
+    finally:
+        with _session_lock:
+            _session["launch_in_progress"] = False
+
+
+def _launch_dolphin_inner(rom_path):
     # Auto-save before killing the current game (covers both navigate-away and
     # game-switching).  Skipped when no game is running, when the emulator
     # already died (crash-relaunch path — a keystroke to a dead process would
@@ -640,6 +656,27 @@ def _xdotool_load_state(slot: int) -> bool:
         return False
     log.info("xdotool: F%d sent to window %s", slot, wid)
     return True
+
+
+def _deferred_load_state(slot: int) -> None:
+    """Resume-from-state: send the load key once the launched game is up.
+
+    Waits for launch_in_progress to clear first — the old instance is dead and
+    gone by then, so any window found afterwards belongs to the new game. The
+    settle delay lets the game boot far enough to accept the hotkey.
+    """
+    deadline = time.monotonic() + RESUME_LOAD_WAIT
+    while time.monotonic() < deadline:
+        with _session_lock:
+            launching = _session["launch_in_progress"]
+            running = _session["rom_path"] is not None
+        if not launching and running and _xdotool_find_window() is not None:
+            time.sleep(RESUME_LOAD_SETTLE)
+            ok = _xdotool_load_state(slot)
+            log.info("resume: deferred load of slot %d %s", slot, "delivered" if ok else "failed")
+            return
+        time.sleep(1.0)
+    log.warning("resume: game window never appeared — slot %d not loaded", slot)
 
 
 def _save_and_exit(slot: int) -> bool:
@@ -1002,7 +1039,21 @@ class BrokerHandler(BaseHTTPRequestHandler):
             self._send_json(422, {"error": "rom_path does not exist", "path": str(rom_path)})
             return
 
+        # Resume-from-state: load this slot once the game window is up.
+        load_slot = body.get("load_slot")
+        if load_slot is not None and (
+            not isinstance(load_slot, int) or not (1 <= load_slot <= 8)
+        ):
+            self._send_json(400, {"error": "load_slot must be 1–8"})
+            return
+
+        with _session_lock:
+            _session["launch_in_progress"] = True
         Thread(target=_launch_dolphin, args=(str(rom_path),), daemon=True).start()
+        if load_slot is not None:
+            Thread(
+                target=_deferred_load_state, args=(load_slot,), daemon=True
+            ).start()
         self._send_json(200, {"status": "launching", "rom_path": str(rom_path)})
 
     def do_DELETE(self):

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -24,10 +24,15 @@ from urllib.parse import parse_qs, urlparse
 PORT       = int(os.environ.get("BROKER_PORT", "8000"))
 SECRET     = os.environ.get("BROKER_SECRET", "")
 ROM_ROOT   = Path(os.environ.get("ROM_ROOT", "/romm/library")).resolve()
-SAVE_SLOT     = int(os.environ.get("SAVE_SLOT", "1"))  # default slot for manual save-and-exit (1–7)
-AUTOSAVE_SLOT = 8                                       # slot 8 is reserved exclusively for auto-saves
-if not (1 <= SAVE_SLOT <= 7):
-    raise SystemExit(f"SAVE_SLOT must be 1–7, got {SAVE_SLOT}")
+MAX_SLOT      = 8                                       # Dolphin maps F1–F8 / Shift+F1–F8 to slots 1–8
+# Every state write — manual save, save-and-exit, auto-save on navigate-away —
+# goes through this one slot, and every read defaults to it. RomM does not
+# offer slot selection, so a second "autosave" slot would only split the
+# library's view of a session across two files. Overridable for debugging.
+SAVE_SLOT     = int(os.environ.get("SAVE_SLOT", str(MAX_SLOT)))
+AUTOSAVE_SLOT = SAVE_SLOT                               # kept as an alias for /config consumers
+if not (1 <= SAVE_SLOT <= MAX_SLOT):
+    raise SystemExit(f"SAVE_SLOT must be 1–{MAX_SLOT}, got {SAVE_SLOT}")
 # Max seconds to poll for the savestate write to complete after the save key.
 # Returns as soon as the file size is stable, so raising this only affects the
 # failure path. Falls back to a fixed 3 s sleep if the StateSaves dir is absent.
@@ -476,12 +481,12 @@ def _launch_dolphin_inner(rom_path, state_path=None):
 
     if do_autosave:
         try:
-            ok = _xdotool_save_state(AUTOSAVE_SLOT)
+            ok = _xdotool_save_state(SAVE_SLOT)
             if ok:
                 log.info("auto-save: saved to slot %d before leaving %s",
-                         AUTOSAVE_SLOT, Path(old_game).name)
+                         SAVE_SLOT, Path(old_game).name)
             else:
-                log.warning("auto-save: xdotool failed for slot %d — continuing anyway", AUTOSAVE_SLOT)
+                log.warning("auto-save: xdotool failed for slot %d — continuing anyway", SAVE_SLOT)
         finally:
             with _session_lock:
                 _session["save_in_progress"] = False
@@ -1148,8 +1153,8 @@ class BrokerHandler(BaseHTTPRequestHandler):
             return
         if slot == 0:
             slot = SAVE_SLOT
-        if not (1 <= slot <= 8):
-            self._send_json(400, {"error": "slot must be 0–8"})
+        if not (1 <= slot <= MAX_SLOT):
+            self._send_json(400, {"error": f"slot must be 0–{MAX_SLOT}"})
             return
 
         # Block while a save is being written so the caller never receives a
@@ -1185,8 +1190,8 @@ class BrokerHandler(BaseHTTPRequestHandler):
             return
         if slot == 0:
             slot = SAVE_SLOT
-        if not (1 <= slot <= AUTOSAVE_SLOT):
-            self._send_json(400, {"error": f"slot must be 0–{AUTOSAVE_SLOT}"})
+        if not (1 <= slot <= MAX_SLOT):
+            self._send_json(400, {"error": f"slot must be 0–{MAX_SLOT}"})
             return
 
         # A save in flight is about to overwrite this slot's thumbnail; wait it
@@ -1415,12 +1420,15 @@ class BrokerHandler(BaseHTTPRequestHandler):
                     return
                 _session["save_in_progress"] = True
             body = self._read_body()
-            slot = body.get("slot", AUTOSAVE_SLOT)
-            if not isinstance(slot, int) or not (1 <= slot <= 8):
+            slot = body.get("slot", SAVE_SLOT)
+            if not isinstance(slot, int) or not (0 <= slot <= MAX_SLOT):
                 with _session_lock:
                     _session["save_in_progress"] = False
-                self._send_json(400, {"error": "slot must be 1–8"})
+                self._send_json(400, {"error": f"slot must be 0–{MAX_SLOT}"})
                 return
+            # Slot 0 means "use the default slot", matching the pcsx2 broker.
+            if slot == 0:
+                slot = SAVE_SLOT
             wait = body.get("wait", True)
             if wait:
                 try:
@@ -1485,12 +1493,15 @@ class BrokerHandler(BaseHTTPRequestHandler):
                     return
                 _session["save_in_progress"] = True
             body = self._read_body()
-            slot = body.get("slot", 1)
-            if not isinstance(slot, int) or not (1 <= slot <= 7):
+            slot = body.get("slot", SAVE_SLOT)
+            if not isinstance(slot, int) or not (0 <= slot <= MAX_SLOT):
                 with _session_lock:
                     _session["save_in_progress"] = False
-                self._send_json(400, {"error": "slot must be 1–7"})
+                self._send_json(400, {"error": f"slot must be 0–{MAX_SLOT}"})
                 return
+            # Slot 0 means "use the default slot", matching the pcsx2 broker.
+            if slot == 0:
+                slot = SAVE_SLOT
 
             def _bg_save(s):
                 try:
@@ -1511,10 +1522,13 @@ class BrokerHandler(BaseHTTPRequestHandler):
                     self._send_json(409, {"error": "no game is running"})
                     return
             body = self._read_body()
-            slot = body.get("slot", 1)
-            if not isinstance(slot, int) or not (1 <= slot <= 8):
-                self._send_json(400, {"error": "slot must be 1–8"})
+            slot = body.get("slot", SAVE_SLOT)
+            if not isinstance(slot, int) or not (0 <= slot <= MAX_SLOT):
+                self._send_json(400, {"error": f"slot must be 0–{MAX_SLOT}"})
                 return
+            # Slot 0 means "use the default slot", matching the pcsx2 broker.
+            if slot == 0:
+                slot = SAVE_SLOT
             ok = _xdotool_load_state(slot)
             self._send_json(200 if ok else 500, {"status": "ok" if ok else "error", "loaded": ok, "slot": slot})
             return
@@ -1549,9 +1563,9 @@ class BrokerHandler(BaseHTTPRequestHandler):
         # Resume-from-state: hand the state to Dolphin at boot.
         load_slot = body.get("load_slot")
         if load_slot is not None and (
-            not isinstance(load_slot, int) or not (1 <= load_slot <= 8)
+            not isinstance(load_slot, int) or not (1 <= load_slot <= MAX_SLOT)
         ):
-            self._send_json(400, {"error": "load_slot must be 1–8"})
+            self._send_json(400, {"error": f"load_slot must be 1–{MAX_SLOT}"})
             return
 
         # Same slot-to-file resolution GET /state-file uses. A resume is always

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""broker.py — launch Dolphin on demand and expose a small HTTP API."""
+"""broker.py: launch Dolphin on demand and expose a small HTTP API."""
 
 import glob
 import hmac
@@ -24,26 +24,37 @@ from urllib.parse import parse_qs, urlparse
 PORT       = int(os.environ.get("BROKER_PORT", "8000"))
 SECRET     = os.environ.get("BROKER_SECRET", "")
 ROM_ROOT   = Path(os.environ.get("ROM_ROOT", "/romm/library")).resolve()
-MAX_SLOT      = 8                                       # Dolphin maps F1–F8 / Shift+F1–F8 to slots 1–8
-# Every state write — manual save, save-and-exit, auto-save on navigate-away —
+MAX_SLOT      = 8                                       # Dolphin maps F1-F8 / Shift+F1-F8 to slots 1-8
+# Every state write (manual save, save-and-exit, auto-save on navigate-away)
 # goes through this one slot, and every read defaults to it. RomM does not
 # offer slot selection, so a second "autosave" slot would only split the
 # library's view of a session across two files. Overridable for debugging.
 SAVE_SLOT     = int(os.environ.get("SAVE_SLOT", str(MAX_SLOT)))
-AUTOSAVE_SLOT = SAVE_SLOT                               # kept as an alias for /config consumers
+AUTOSAVE_SLOT = SAVE_SLOT                               # /status reports both names
 if not (1 <= SAVE_SLOT <= MAX_SLOT):
-    raise SystemExit(f"SAVE_SLOT must be 1–{MAX_SLOT}, got {SAVE_SLOT}")
+    raise SystemExit(f"SAVE_SLOT must be 1-{MAX_SLOT}, got {SAVE_SLOT}")
 # Max seconds to poll for the savestate write to complete after the save key.
 # Returns as soon as the file size is stable, so raising this only affects the
 # failure path. Falls back to a fixed 3 s sleep if the StateSaves dir is absent.
 SSTATE_WAIT   = float(os.environ.get("SSTATE_WAIT", "10.0"))
 
-# Dolphin writes savestates to StateSaves under its data dir; the location
-# varies by build (XDG vs. non-XDG layout), so both are probed at save time.
-_SSTATE_DIR_CANDIDATES = (
-    Path("/config/.local/share/dolphin-emu/StateSaves"),
-    Path("/config/.config/dolphin-emu/StateSaves"),
+# Dashboard crash-relaunch policy. A Dolphin that survives longer than the
+# healthy threshold clears the failure count; anything shorter is treated as a
+# crash loop and backed off, then abandoned.
+RELAUNCH_HEALTHY_SECONDS = 5.0
+RELAUNCH_BACKOFF_BASE    = 5
+RELAUNCH_BACKOFF_CAP     = 60
+RELAUNCH_MAX_FAILURES    = 5
+
+# Dolphin's data dir; the location varies by build (XDG vs. non-XDG layout), so
+# both are probed at use time. Savestates, screenshots and the memory card all
+# hang off this one root: probing for each independently let a state resolve
+# under one candidate while its thumbnail resolved under the other.
+_SAVE_DATA_ROOTS = (
+    Path("/config/.local/share/dolphin-emu"),
+    Path("/config/.config/dolphin-emu"),
 )
+_SSTATE_DIR_CANDIDATES = tuple(r / "StateSaves" for r in _SAVE_DATA_ROOTS)
 
 # Dolphin's EXIDeviceType for a GCI folder card (Source/Core/Core/HW/EXI/EXI_Device.h).
 EXI_MEMORY_CARD_FOLDER = 8
@@ -54,7 +65,7 @@ ENV = {
     # creates a VK_KHR_wayland_surface and renders directly to the Wayland
     # compositor, leaving the X11 window black.  Without it, Vulkan uses
     # VK_KHR_xcb_surface and renders into the X11 window that Xwayland
-    # composites into labwc — which is what selkies captures.
+    # composites into labwc, which is what selkies captures.
     "XDG_RUNTIME_DIR":    "/config/.XDG",
     "QT_QPA_PLATFORM":    "xcb",
     "PULSE_RUNTIME_PATH": "/defaults",
@@ -72,7 +83,7 @@ ENV = {
 }
 
 # Dolphin on this image writes all config files directly to
-# ~/.config/dolphin-emu/ — there is no Config/ subdirectory.
+# ~/.config/dolphin-emu/. There is no Config/ subdirectory.
 INI_PATH = Path("/config/.config/dolphin-emu/Dolphin.ini")
 
 # Dolphin's stdout/stderr is redirected at fd level to this file. A Python
@@ -93,6 +104,13 @@ log = logging.getLogger("broker")
 # ── Session state ─────────────────────────────────────────────────────────────
 
 _session_lock = Lock()
+# Serialises whole launch sequences. _session_lock only guards the dict; two
+# concurrent /launch requests used to interleave their kill/patch/spawn steps
+# and leave two Dolphins running, or none.
+_launch_lock = Lock()
+# Serialises card hydration. The staging and backup dirs were named after the
+# pid, which is the same pid for every thread of this server.
+_memory_card_lock = Lock()
 _session: dict = {
     "process":          None,
     "rom_path":         None,
@@ -100,13 +118,12 @@ _session: dict = {
     "started_at":       None,
     "is_managed":       False,
     "save_in_progress": False,
-    # True from POST /launch until _launch_dolphin has swapped instances —
-    # gates the deferred resume load so it never fires at the old window.
-    "launch_in_progress": False,
     # Wall-clock stamp of the last GAME launch (not dashboard relaunches).
     # GET /save-file only ships files modified at or after this point; it
     # survives game exit so RomM can still pull after the session ends.
     "save_baseline": None,
+    # Consecutive short-lived dashboard exits; see _monitor_process.
+    "relaunch_failures": 0,
 }
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -126,7 +143,7 @@ def _chown_abc(path: Path):
     """Hand a broker-written file back to abc.
 
     The broker runs as root, so anything it writes lands root-owned and
-    Dolphin (running as abc) can read but never rewrite it — every setting
+    Dolphin (running as abc) can read but never rewrite it, so every setting
     Dolphin tries to persist is then silently dropped.
     """
     try:
@@ -144,7 +161,7 @@ def _patch_ini(fullscreen: bool = False):
     try:
         INI_PATH.parent.mkdir(parents=True, exist_ok=True)
     except OSError as exc:
-        log.error("Could not create %s: %s — skipping ini patch",
+        log.error("Could not create %s: %s, skipping ini patch",
                   INI_PATH.parent, exc)
         return
 
@@ -182,7 +199,7 @@ def _patch_ini(fullscreen: bool = False):
                 "PermissionAsked = True\n"
             )
         except OSError as exc:
-            log.error("Could not create %s: %s — broker defaults not applied",
+            log.error("Could not create %s: %s, broker defaults not applied",
                       INI_PATH, exc)
             return
         _chown_abc(INI_PATH)
@@ -191,7 +208,7 @@ def _patch_ini(fullscreen: bool = False):
 
     # Both keys below feed Core::UpdateInputGate, which drives the single
     # global ControlReference input gate. When that gate is shut every
-    # ControlReference reads 0 — hotkeys, GC pads and Wiimotes alike — so a
+    # ControlReference reads 0 (hotkeys, GC pads and Wiimotes alike), so a
     # wrong value here kills xdotool and browser gamepad input together.
     #
     # Section names are Dolphin's, not ours, and the two differ:
@@ -258,7 +275,7 @@ def _patch_ini(fullscreen: bool = False):
             if not missing:
                 continue
             header_idx = next(
-                (i for i, l in enumerate(new_lines) if l.strip() == f"[{section}]"),
+                (i for i, line in enumerate(new_lines) if line.strip() == f"[{section}]"),
                 None,
             )
             add_lines = [f"{k} = {v}" for k, v in missing.items()]
@@ -268,15 +285,23 @@ def _patch_ini(fullscreen: bool = False):
             else:
                 new_lines[header_idx + 1:header_idx + 1] = add_lines
             for k in missing:
-                log.warning("Dolphin.ini: [%s] %s not found — inserted", section, k)
+                log.warning("Dolphin.ini: [%s] %s not found, inserted", section, k)
 
         tmp = INI_PATH.with_suffix(".tmp")
         tmp.write_text("\n".join(new_lines) + "\n")
         tmp.replace(INI_PATH)
         _chown_abc(INI_PATH)
-        log.debug("Dolphin.ini patched (ConfirmStop)")
-    except Exception as exc:
+        log.debug("Dolphin.ini patched")
+    except (OSError, UnicodeDecodeError) as exc:
+        # Only I/O and a non-text ini are expected to fail here (read-only
+        # /config, disk full, a half-written file from a previous crash).
+        # Anything else is a bug in the patcher and should surface as a
+        # traceback rather than be logged and shrugged off.
         log.error("Failed to patch Dolphin.ini: %s", exc)
+        try:
+            INI_PATH.with_suffix(".tmp").unlink()
+        except OSError:
+            pass
 
 
 def _kill_dolphin():
@@ -299,12 +324,12 @@ def _kill_dolphin():
         try:
             proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
-            log.warning("Dolphin did not exit after SIGTERM — sending SIGKILL")
+            log.warning("Dolphin did not exit after SIGTERM: sending SIGKILL")
             os.killpg(pgid, signal.SIGKILL)
             try:
                 proc.wait(timeout=10)
             except subprocess.TimeoutExpired:
-                log.error("Dolphin did not exit after SIGKILL — giving up")
+                log.error("Dolphin did not exit after SIGKILL: giving up")
     except ProcessLookupError:
         pass  # already gone
 
@@ -317,10 +342,32 @@ def _wait_dolphin_gone(timeout: float = 5.0) -> None:
         if subprocess.run(["pgrep", "-x", "dolphin-emu"], capture_output=True).returncode != 0:
             return
         time.sleep(0.2)
-    log.warning("dolphin-emu still running after %.1fs — continuing anyway", timeout)
+    log.warning("dolphin-emu still running after %.1fs, continuing anyway", timeout)
 
 
-def _launch_dolphin_internal(rom_path, state_path=None):
+DISPLAY_WAIT = float(os.environ.get("DISPLAY_WAIT", "30.0"))
+
+
+def _wait_for_display(timeout: float = DISPLAY_WAIT) -> bool:
+    """Block until the X server's socket exists, or the timeout expires.
+
+    Replaces a flat 5 s sleep: on a cold container the desktop is often not up
+    yet at 5 s (so the first Dolphin launch failed silently), and on a warm one
+    the sleep was 5 s of dead time before the broker would answer /health.
+    """
+    sock = Path(f"/tmp/.X11-unix/X{ENV['DISPLAY'].lstrip(':').split('.')[0]}")
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if sock.exists():
+            log.info("Display %s is up", ENV["DISPLAY"])
+            return True
+        time.sleep(0.25)
+    log.warning("Display %s did not appear within %.0fs, starting anyway",
+                ENV["DISPLAY"], timeout)
+    return False
+
+
+def _spawn_dolphin(rom_path, state_path=None):
     """Launch dolphin-emu as abc via sudo+env."""
     cmd = [
         "sudo", "-u", "abc", "env",
@@ -335,7 +382,7 @@ def _launch_dolphin_internal(rom_path, state_path=None):
         # loop, which is where SDL joystick polling happens.  Without the event
         # loop, controller input never reaches the running game.  Without
         # --batch, when emulation stops Dolphin returns to its main menu rather
-        # than exiting — this is the desired idle behaviour.
+        # than exiting, which is the desired idle behaviour.
         cmd.append(f"--exec={rom_path}")
 
         # Resume-from-state is done at boot, not by a deferred hotkey. Dolphin
@@ -402,13 +449,33 @@ def _monitor_process(proc, start_time):
     if not should_relaunch:
         return
 
-    wait_time = 5 if duration < 5 else 1
-    log.info("Dolphin exited after %.1fs — relaunching dashboard in %ds", duration, wait_time)
+    # A dashboard that dies immediately dies again on relaunch, so back off and
+    # eventually stop: an uncapped loop respawned a broken Dolphin forever and
+    # buried the reason under thousands of identical log lines.
+    if duration >= RELAUNCH_HEALTHY_SECONDS:
+        failures = 0
+        wait_time = 1
+    else:
+        with _session_lock:
+            failures = _session["relaunch_failures"] + 1
+        if failures > RELAUNCH_MAX_FAILURES:
+            log.error(
+                "Dolphin exited after %.1fs on %d consecutive relaunches, giving up",
+                duration, failures - 1,
+            )
+            with _session_lock:
+                _session["is_managed"] = False
+                _session["relaunch_failures"] = 0
+            return
+        wait_time = min(RELAUNCH_BACKOFF_CAP, RELAUNCH_BACKOFF_BASE * 2 ** (failures - 1))
+
+    log.info("Dolphin exited after %.1fs, relaunching dashboard in %ds", duration, wait_time)
     time.sleep(wait_time)
 
     with _session_lock:
         if not _session["is_managed"]:
             return
+        _session["relaunch_failures"] = failures
 
     _launch_dolphin(None)
 
@@ -416,7 +483,7 @@ def _monitor_process(proc, start_time):
 def _cleanup_stale_sockets():
     """Remove only stale/unreachable selkies socket files.
 
-    Does NOT send EOF — sending EOF disconnects the browser gamepad client,
+    Does NOT send EOF: sending EOF disconnects the browser gamepad client,
     which breaks input for the new Dolphin instance. The interposer will
     reconnect to existing sockets automatically; we only clean up sockets
     that have become orphaned (no listener on the other end).
@@ -452,17 +519,14 @@ def _cleanup_stale_sockets():
 
 
 def _launch_dolphin(rom_path, state_path=None):
-    try:
-        _launch_dolphin_inner(rom_path, state_path)
-    finally:
-        with _session_lock:
-            _session["launch_in_progress"] = False
+    with _launch_lock:
+        _launch_dolphin_locked(rom_path, state_path)
 
 
-def _launch_dolphin_inner(rom_path, state_path=None):
+def _launch_dolphin_locked(rom_path, state_path=None):
     # Auto-save before killing the current game (covers both navigate-away and
     # game-switching).  Skipped when no game is running, when the emulator
-    # already died (crash-relaunch path — a keystroke to a dead process would
+    # already died (crash-relaunch path, where a keystroke to a dead process would
     # just poll for a savestate write that never comes), or when a save is
     # already in progress (e.g. called from /save-and-exit which saves first
     # then kills).  Read and set save_in_progress atomically to avoid a TOCTOU
@@ -486,7 +550,7 @@ def _launch_dolphin_inner(rom_path, state_path=None):
                 log.info("auto-save: saved to slot %d before leaving %s",
                          SAVE_SLOT, Path(old_game).name)
             else:
-                log.warning("auto-save: xdotool failed for slot %d — continuing anyway", SAVE_SLOT)
+                log.warning("auto-save: xdotool failed for slot %d, continuing anyway", SAVE_SLOT)
         finally:
             with _session_lock:
                 _session["save_in_progress"] = False
@@ -506,7 +570,7 @@ def _launch_dolphin_inner(rom_path, state_path=None):
         # save pull still sees the files the last game wrote.
         if rom_path:
             _session["save_baseline"] = time.time()
-    _launch_dolphin_internal(rom_path, state_path)
+    _spawn_dolphin(rom_path, state_path)
 
 
 # ── xdotool helpers ───────────────────────────────────────────────────────────
@@ -541,6 +605,9 @@ def _xdotool_find_window() -> str | None:
                 xdo_base + ["search", "--onlyvisible", "--pid", pid],
                 text=True, timeout=5,
             )
+            # Last, not first: xdotool lists in creation order and Dolphin's
+            # render window is created after the main window it replaces, so the
+            # newest ID is the one that actually has keyboard focus.
             ids = out.strip().split()
             if ids:
                 wid = ids[-1]
@@ -590,7 +657,11 @@ def _sstate_dir() -> Path | None:
     for c in _SSTATE_DIR_CANDIDATES:
         if c.is_dir():
             return c
-    return None
+    # Dolphin has not written a state yet. Derive the dir from the same root
+    # the screenshots and memory card resolve against, so a PUT that arrives
+    # before the first save still lands where the next save will look.
+    root = _save_data_root()
+    return root / "StateSaves" if root else None
 
 
 def _sstate_snapshot(state_dir: Path) -> dict:
@@ -634,7 +705,7 @@ def _wait_for_sstate_write(state_dir: Path, before: dict, deadline: float, slot:
                 prev = before.get(p)
                 if prev is None or prev[1] != mtime:
                     target, last_size, stable_since = p, size, time.monotonic()
-                    log.debug("Save: write detected — %s (%d bytes)", p.name, size)
+                    log.debug("Save: write detected: %s (%d bytes)", p.name, size)
                     break
         else:
             cur = after.get(target)
@@ -643,7 +714,7 @@ def _wait_for_sstate_write(state_dir: Path, before: dict, deadline: float, slot:
             elif cur[0] != last_size:
                 last_size, stable_since = cur[0], time.monotonic()
             elif time.monotonic() - stable_since >= STABLE_SECS:
-                log.info("Save: state write complete — %s (%d bytes)", target.name, last_size)
+                log.info("Save: state write complete: %s (%d bytes)", target.name, last_size)
                 return True
         time.sleep(POLL_SECS)
     return False
@@ -685,9 +756,9 @@ def _newest_state_for_slot(slot: int) -> Path | None:
 
 
 def _xdotool_save_state(slot: int) -> bool:
-    """Save emulator state to slot (1–8) via Shift+F{slot}.
+    """Save emulator state to slot (1-8) via Shift+F{slot}.
 
-    Dolphin maps Shift+F1–Shift+F8 directly to save slots 1–8, so no slot
+    Dolphin maps Shift+F1-Shift+F8 directly to save slots 1-8, so no slot
     cycling is needed. Sends the key then polls StateSaves for the write to
     complete (up to SSTATE_WAIT seconds) so a follow-up kill cannot land
     mid-flush. Falls back to a fixed 3 s sleep if StateSaves can't be found.
@@ -705,20 +776,20 @@ def _xdotool_save_state(slot: int) -> bool:
         return False
 
     if state_dir is None:
-        log.warning("Save: StateSaves dir not found — falling back to fixed 3.0s wait")
+        log.warning("Save: StateSaves dir not found, falling back to fixed 3.0s wait")
         time.sleep(3.0)
         return True
 
-    log.info("xdotool: shift+F%d sent to window %s — waiting for write (max %.1fs)", slot, wid, SSTATE_WAIT)
+    log.info("xdotool: shift+F%d sent to window %s, waiting for write (max %.1fs)", slot, wid, SSTATE_WAIT)
     if not _wait_for_sstate_write(state_dir, before, time.monotonic() + SSTATE_WAIT, slot):
         log.warning("Save: state write not confirmed within %.1fs (key was sent)", SSTATE_WAIT)
     return True
 
 
 def _xdotool_load_state(slot: int) -> bool:
-    """Load emulator state from slot (1–8) via F{slot}.
+    """Load emulator state from slot (1-8) via F{slot}.
 
-    Dolphin maps F1–F8 directly to load slots 1–8.
+    Dolphin maps F1-F8 directly to load slots 1-8.
     """
     wid = _xdotool_find_window()
     if wid is None:
@@ -771,7 +842,7 @@ def _pactl_get_mute() -> bool | None:
     return result.stdout.strip().endswith("yes")
 
 
-def _cleanup_sockets():
+def _restart_selkies():
     """Restart selkies to flush all stale gamepad connections."""
     log.info("Socket cleanup: restarting selkies...")
     result = subprocess.run(["pkill", "-15", "-f", "selkies"], capture_output=True)
@@ -787,10 +858,7 @@ def _cleanup_sockets():
 # every save file modified since the last game launch; PUT /save-file restores
 # a pulled archive before launch. Same guarded, mtime-last-write-wins mechanics
 # as Eden's implementation.
-_SAVE_DATA_ROOTS = (
-    Path("/config/.local/share/dolphin-emu"),
-    Path("/config/.config/dolphin-emu"),
-)
+#
 # Archive members must live under one of these root-relative subtrees; PUT
 # rejects anything else so a crafted zip cannot reach configs, keys or states.
 # The Slot-A card is listed so GameCube saves still round-trip on a container
@@ -816,22 +884,28 @@ def _save_data_root() -> Path | None:
 
 def _iter_save_files(root: Path) -> list[Path]:
     """Every regular file under the allowed save subtrees, sorted for a
-    deterministic archive (identical content zips to identical bytes)."""
+    deterministic archive (identical content zips to identical bytes).
+
+    os.walk, not rglob: rglob descends into symlinked directories, so a link
+    planted under GC/ would pull an arbitrary tree into the archive.
+    """
     files: list[Path] = []
     for sub in SAVE_SYNC_SUBTREES:
         base = root / sub
-        if not base.is_dir():
+        if base.is_symlink() or not base.is_dir():
             continue
-        files.extend(
-            p for p in sorted(base.rglob("*")) if p.is_file() and not p.is_symlink()
-        )
-    return files
+        for dirpath, _dirnames, filenames in os.walk(base):
+            for name in filenames:
+                p = Path(dirpath, name)
+                if p.is_file() and not p.is_symlink():
+                    files.append(p)
+    return sorted(files)
 
 
 def _build_save_archive(baseline: float) -> bytes | None:
     """Zip every save file modified since the last game launch.
 
-    Returns None when there is nothing to sync — no data dir yet, or no file
+    Returns None when there is nothing to sync: no data dir yet, or no file
     changed since `baseline`. Member paths are relative to the data dir so a
     later PUT restores them regardless of which candidate dir is live."""
     root = _save_data_root()
@@ -859,7 +933,7 @@ def _build_save_archive(baseline: float) -> bytes | None:
             try:
                 zf.write(p, p.relative_to(root).as_posix())
             except OSError as exc:
-                log.warning("save-file: could not read %s — %s", p, exc)
+                log.warning("save-file: could not read %s: %s", p, exc)
     return buf.getvalue()
 
 
@@ -884,7 +958,11 @@ def _extract_save_archive(content: bytes) -> tuple[int, int] | str:
 
     Returns (written, skipped) on success, or an error string for a bad
     archive. Existing files newer than their archive member are skipped so a
-    restore can never roll back saves made since the archive was taken."""
+    restore can never roll back saves made since the archive was taken.
+
+    Every member is written to a temp file first and only renamed into place
+    once all of them are on disk: a failure partway through used to leave the
+    save tree half restored, with no record of which half."""
     root = _save_data_root() or _SAVE_DATA_ROOTS[0]
     try:
         zf = zipfile.ZipFile(io.BytesIO(content))
@@ -903,11 +981,12 @@ def _extract_save_archive(content: bytes) -> tuple[int, int] | str:
             ):
                 return f"archive member outside save subtrees: {info.filename}"
 
-        written = skipped = 0
-        for info in infos:
-            target = root / PurePosixPath(info.filename)
-            mtime = time.mktime(info.date_time + (0, 0, -1))
-            try:
+        staged: list[tuple[Path, Path, float]] = []
+        skipped = 0
+        try:
+            for info in infos:
+                target = root / PurePosixPath(info.filename)
+                mtime = time.mktime(info.date_time + (0, 0, -1))
                 if (
                     target.exists()
                     and target.stat().st_mtime > mtime + _SAVE_MTIME_SLACK
@@ -918,12 +997,25 @@ def _extract_save_archive(content: bytes) -> tuple[int, int] | str:
                 tmp = target.parent / f".{target.name}.tmp"
                 tmp.write_bytes(zf.read(info))
                 os.chown(tmp, _LOG_UID, _LOG_GID)
+                staged.append((tmp, target, mtime))
+        except OSError as exc:
+            for tmp, _target, _mtime in staged:
+                try:
+                    tmp.unlink()
+                except OSError:
+                    pass
+            return f"could not write {info.filename}: {exc}"
+
+        for tmp, target, mtime in staged:
+            try:
                 os.replace(tmp, target)
                 os.utime(target, (mtime, mtime))
             except OSError as exc:
-                return f"could not write {info.filename}: {exc}"
-            written += 1
-    return (written, skipped)
+                # Past the point of no return: some files are already live.
+                # Report it rather than pretending the restore was clean.
+                log.error("save-file: could not commit %s: %s", target, exc)
+                return f"could not write {target.name}: {exc}"
+    return (len(staged), skipped)
 
 
 # ── State screenshots ─────────────────────────────────────────────────────────
@@ -977,7 +1069,10 @@ def _capture_state_screenshot(wid: str, slot: int) -> bool:
         return False
 
     # The hotkey returns before the encode finishes, so wait for a stable size.
+    # This gets its own budget: sharing the appear deadline meant a PNG that
+    # showed up late was filed at whatever size it happened to be mid-encode.
     last = -1
+    deadline = time.monotonic() + SCREENSHOT_WAIT
     while time.monotonic() < deadline:
         try:
             size = shot.stat().st_size
@@ -987,6 +1082,8 @@ def _capture_state_screenshot(wid: str, slot: int) -> bool:
             break
         last = size
         time.sleep(0.2)
+    else:
+        log.warning("screenshot: %s never stopped growing, filing it anyway", shot.name)
 
     target = _state_shot_path(slot)
     try:
@@ -1050,6 +1147,11 @@ def _build_memory_card_archive() -> bytes | None | str:
 
 
 def _replace_memory_card(content: bytes) -> tuple[int] | str:
+    with _memory_card_lock:
+        return _replace_memory_card_locked(content)
+
+
+def _replace_memory_card_locked(content: bytes) -> tuple[int] | str:
     """Wipe the Slot-A card and lay down the pulled card image. Returns
     (written,) on success or an error string. The whole card is replaced (no
     per-file mtime merge): this is the hydrate-with-isolation guarantee for
@@ -1073,8 +1175,8 @@ def _replace_memory_card(content: bytes) -> tuple[int] | str:
                 return f"archive member escapes card dir: {info.filename}"
 
         parent = path.parent
-        staging = parent / f".{path.name}.new-{os.getpid()}"
-        backup = parent / f".{path.name}.old-{os.getpid()}"
+        staging = parent / f".{path.name}.new"
+        backup = parent / f".{path.name}.old"
         shutil.rmtree(staging, ignore_errors=True)
         try:
             _mkdirs_owned(staging)
@@ -1140,7 +1242,12 @@ class BrokerHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(payload)
 
-    def _read_body(self) -> dict:
+    def _read_body(self) -> dict | None:
+        """Parsed JSON body, or None once a 400 has been sent for a bad one.
+
+        Malformed JSON used to read back as {}, so a typo'd /launch silently
+        became a dashboard relaunch instead of an error the caller could see.
+        """
         try:
             length = max(0, min(int(self.headers.get("Content-Length", 0)), 64 * 1024))
         except ValueError:
@@ -1148,9 +1255,14 @@ class BrokerHandler(BaseHTTPRequestHandler):
         if length == 0:
             return {}
         try:
-            return json.loads(self.rfile.read(length))
-        except json.JSONDecodeError:
-            return {}
+            body = json.loads(self.rfile.read(length))
+        except json.JSONDecodeError as exc:
+            self._send_json(400, {"error": f"invalid JSON body: {exc.msg}"})
+            return None
+        if not isinstance(body, dict):
+            self._send_json(400, {"error": "body must be a JSON object"})
+            return None
+        return body
 
     def _get_state_file(self):
         query = parse_qs(urlparse(self.path).query)
@@ -1162,7 +1274,7 @@ class BrokerHandler(BaseHTTPRequestHandler):
         if slot == 0:
             slot = SAVE_SLOT
         if not (1 <= slot <= MAX_SLOT):
-            self._send_json(400, {"error": f"slot must be 0–{MAX_SLOT}"})
+            self._send_json(400, {"error": f"slot must be 0-{MAX_SLOT}"})
             return
 
         # Block while a save is being written so the caller never receives a
@@ -1174,6 +1286,11 @@ class BrokerHandler(BaseHTTPRequestHandler):
             self._send_json(404, {"error": "no state file for slot", "slot": slot})
             return
         try:
+            # Size first: reading then measuring would pull an oversized state
+            # entirely into memory only to refuse it.
+            if state_path.stat().st_size > STATE_FILE_MAX_BYTES:
+                self._send_json(413, {"error": "state file exceeds size limit"})
+                return
             content = state_path.read_bytes()
         except OSError as exc:
             self._send_json(500, {"error": f"could not read state file: {exc}"})
@@ -1199,7 +1316,7 @@ class BrokerHandler(BaseHTTPRequestHandler):
         if slot == 0:
             slot = SAVE_SLOT
         if not (1 <= slot <= MAX_SLOT):
-            self._send_json(400, {"error": f"slot must be 0–{MAX_SLOT}"})
+            self._send_json(400, {"error": f"slot must be 0-{MAX_SLOT}"})
             return
 
         # A save in flight is about to overwrite this slot's thumbnail; wait it
@@ -1226,12 +1343,23 @@ class BrokerHandler(BaseHTTPRequestHandler):
         with _session_lock:
             baseline = _session["save_baseline"]
             rom_name = _session["rom_name"]
+        # Both misses are 404, so they are tagged: "unchanged" means the card is
+        # good and RomM should keep what it has, "absent" means there is nothing
+        # to compare against. An untagged 404 is a missing endpoint.
         if baseline is None:
-            self._send_json(404, {"error": "no game has been launched"})
+            self._send_json(
+                404,
+                {"error": "no game has been launched"},
+                headers={"X-Save-File": "absent"},
+            )
             return
         archive = _build_save_archive(baseline)
         if archive is None:
-            self._send_json(404, {"error": "no save changes since last launch"})
+            self._send_json(
+                404,
+                {"error": "no save changes since last launch"},
+                headers={"X-Save-File": "unchanged"},
+            )
             return
         # Header values must be latin-1; ROM stems can be anything.
         safe_name = "".join(
@@ -1257,12 +1385,15 @@ class BrokerHandler(BaseHTTPRequestHandler):
             self._send_json(413, {"error": "archive too large"})
             return
         content = self.rfile.read(length)
+        if len(content) != length:
+            self._send_json(400, {"error": "truncated request body"})
+            return
         result = _extract_save_archive(content)
         if isinstance(result, str):
             self._send_json(400, {"error": result})
             return
         written, skipped = result
-        log.info("save-file: restored archive — %d written, %d skipped", written, skipped)
+        log.info("save-file: restored archive: %d written, %d skipped", written, skipped)
         self._send_json(200, {"status": "ok", "written": written, "skipped": skipped})
 
     def _get_memory_card(self):
@@ -1308,7 +1439,7 @@ class BrokerHandler(BaseHTTPRequestHandler):
             self._send_json(400, {"error": result})
             return
         (written,) = result
-        log.info("memory-card: replaced slot-A card — %d files", written)
+        log.info("memory-card: replaced slot-A card: %d files", written)
         self._send_json(200, {"status": "ok", "written": written})
 
     def do_PUT(self):
@@ -1326,7 +1457,7 @@ class BrokerHandler(BaseHTTPRequestHandler):
             self._send_json(404, {"error": "not found"})
             return
 
-        # Basename only — the filename came from a previous GET and is written
+        # Basename only: the filename came from a previous GET and is written
         # back verbatim so Dolphin recognises the slot; path parts are rejected.
         raw_name = parse_qs(parsed.query).get("filename", [""])[0]
         filename = Path(raw_name).name
@@ -1414,7 +1545,7 @@ class BrokerHandler(BaseHTTPRequestHandler):
             return
 
         if self.path == "/cleanup":
-            Thread(target=_cleanup_sockets, daemon=True).start()
+            Thread(target=_restart_selkies, daemon=True).start()
             self._send_json(200, {"status": "cleanup started"})
             return
 
@@ -1428,11 +1559,15 @@ class BrokerHandler(BaseHTTPRequestHandler):
                     return
                 _session["save_in_progress"] = True
             body = self._read_body()
+            if body is None:
+                with _session_lock:
+                    _session["save_in_progress"] = False
+                return
             slot = body.get("slot", SAVE_SLOT)
             if not isinstance(slot, int) or not (0 <= slot <= MAX_SLOT):
                 with _session_lock:
                     _session["save_in_progress"] = False
-                self._send_json(400, {"error": f"slot must be 0–{MAX_SLOT}"})
+                self._send_json(400, {"error": f"slot must be 0-{MAX_SLOT}"})
                 return
             # Slot 0 means "use the default slot", matching the pcsx2 broker.
             if slot == 0:
@@ -1445,7 +1580,7 @@ class BrokerHandler(BaseHTTPRequestHandler):
                     with _session_lock:
                         _session["save_in_progress"] = False
                 if not ok:
-                    log.warning("save-and-exit: save key failed (slot %d) — killed anyway", slot)
+                    log.warning("save-and-exit: save key failed (slot %d), killed anyway", slot)
                 self._send_json(200, {"status": "ok", "saved": ok, "slot": slot})
                 Thread(target=_launch_dolphin, args=(None,), daemon=True).start()
             else:
@@ -1456,7 +1591,7 @@ class BrokerHandler(BaseHTTPRequestHandler):
                         with _session_lock:
                             _session["save_in_progress"] = False
                     if not ok:
-                        log.warning("save-and-exit: save key failed (slot %d) — killed anyway", s)
+                        log.warning("save-and-exit: save key failed (slot %d), killed anyway", s)
                     _launch_dolphin(None)
                 Thread(target=_bg, args=(slot,), daemon=True).start()
                 self._send_json(200, {"status": "queued", "slot": slot})
@@ -1464,9 +1599,11 @@ class BrokerHandler(BaseHTTPRequestHandler):
 
         if self.path == "/volume":
             body = self._read_body()
+            if body is None:
+                return
             level = body.get("level")
             if not isinstance(level, int) or not (0 <= level <= 100):
-                self._send_json(400, {"error": "level must be an integer 0–100"})
+                self._send_json(400, {"error": "level must be an integer 0-100"})
                 return
             result = _pactl("set-sink-volume", "@DEFAULT_SINK@", f"{level}%")
             if result.returncode != 0:
@@ -1478,6 +1615,8 @@ class BrokerHandler(BaseHTTPRequestHandler):
 
         if self.path == "/mute":
             body = self._read_body()
+            if body is None:
+                return
             if "mute" in body:
                 mute_arg = "1" if body["mute"] else "0"
             else:
@@ -1501,11 +1640,15 @@ class BrokerHandler(BaseHTTPRequestHandler):
                     return
                 _session["save_in_progress"] = True
             body = self._read_body()
+            if body is None:
+                with _session_lock:
+                    _session["save_in_progress"] = False
+                return
             slot = body.get("slot", SAVE_SLOT)
             if not isinstance(slot, int) or not (0 <= slot <= MAX_SLOT):
                 with _session_lock:
                     _session["save_in_progress"] = False
-                self._send_json(400, {"error": f"slot must be 0–{MAX_SLOT}"})
+                self._send_json(400, {"error": f"slot must be 0-{MAX_SLOT}"})
                 return
             # Slot 0 means "use the default slot", matching the pcsx2 broker.
             if slot == 0:
@@ -1530,9 +1673,11 @@ class BrokerHandler(BaseHTTPRequestHandler):
                     self._send_json(409, {"error": "no game is running"})
                     return
             body = self._read_body()
+            if body is None:
+                return
             slot = body.get("slot", SAVE_SLOT)
             if not isinstance(slot, int) or not (0 <= slot <= MAX_SLOT):
-                self._send_json(400, {"error": f"slot must be 0–{MAX_SLOT}"})
+                self._send_json(400, {"error": f"slot must be 0-{MAX_SLOT}"})
                 return
             # Slot 0 means "use the default slot", matching the pcsx2 broker.
             if slot == 0:
@@ -1551,7 +1696,10 @@ class BrokerHandler(BaseHTTPRequestHandler):
                 return
 
         body = self._read_body()
-        raw_path = body.get("rom_path", "").strip()
+        if body is None:
+            return
+        raw_path = body.get("rom_path")
+        raw_path = raw_path.strip() if isinstance(raw_path, str) else ""
 
         if not raw_path:
             self._send_json(400, {"error": "rom_path is required"})
@@ -1570,11 +1718,13 @@ class BrokerHandler(BaseHTTPRequestHandler):
 
         # Resume-from-state: hand the state to Dolphin at boot.
         load_slot = body.get("load_slot")
-        if load_slot is not None and (
-            not isinstance(load_slot, int) or not (1 <= load_slot <= MAX_SLOT)
-        ):
-            self._send_json(400, {"error": f"load_slot must be 1–{MAX_SLOT}"})
-            return
+        if load_slot is not None:
+            if not isinstance(load_slot, int) or not (0 <= load_slot <= MAX_SLOT):
+                self._send_json(400, {"error": f"load_slot must be 0-{MAX_SLOT}"})
+                return
+            # Slot 0 means "use the default slot", as it does on every other route.
+            if load_slot == 0:
+                load_slot = SAVE_SLOT
 
         # Same slot-to-file resolution GET /state-file uses. A resume is always
         # preceded by RomM PUTting the state, so the newest file for the slot is
@@ -1590,8 +1740,6 @@ class BrokerHandler(BaseHTTPRequestHandler):
                 })
                 return
 
-        with _session_lock:
-            _session["launch_in_progress"] = True
         Thread(
             target=_launch_dolphin,
             args=(str(rom_path), str(state_path) if state_path else None),
@@ -1618,12 +1766,25 @@ class BrokerHandler(BaseHTTPRequestHandler):
 
 # ── Main ──────────────────────────────────────────────────────────────────────
 
+_shutting_down = False
+
+
 def _graceful_shutdown(server: HTTPServer, signum: int) -> None:
     """Stop the HTTP listener, let any in-flight save finish, then kill Dolphin.
-    Triggered on SIGTERM/SIGINT — serve_forever()'s KeyboardInterrupt path does
+    Triggered on SIGTERM/SIGINT: serve_forever()'s KeyboardInterrupt path does
     not cover SIGTERM from s6/systemd, which previously hard-killed Dolphin
-    mid-savestate on container stop."""
-    log.info("Received signal %d — beginning graceful shutdown", signum)
+    mid-savestate on container stop.
+
+    The wait runs in the signal handler, so it blocks the main thread. A second
+    signal arriving during it (s6 escalating, or an impatient Ctrl-C) means the
+    operator wants out now, so it skips the wait rather than re-entering it."""
+    global _shutting_down
+    if _shutting_down:
+        log.warning("Received signal %d during shutdown, killing Dolphin now", signum)
+        _kill_dolphin()
+        return
+    _shutting_down = True
+    log.info("Received signal %d, beginning graceful shutdown", signum)
     Thread(target=server.shutdown, daemon=True).start()
 
     deadline = time.monotonic() + max(SSTATE_WAIT, 5.0)
@@ -1633,17 +1794,16 @@ def _graceful_shutdown(server: HTTPServer, signum: int) -> None:
                 break
         time.sleep(0.2)
     else:
-        log.warning("Shutdown: in-flight save did not complete within %.1fs — killing Dolphin anyway", SSTATE_WAIT)
+        log.warning("Shutdown: in-flight save did not complete within %.1fs, killing Dolphin anyway", SSTATE_WAIT)
 
     _kill_dolphin()
     log.info("Shutdown complete")
 
 
 def main():
-    log.info("Broker starting — waiting 5s for desktop...")
     if not SECRET:
-        log.warning("BROKER_SECRET is not set — all POST/DELETE endpoints are unauthenticated")
-    time.sleep(5)
+        log.warning("BROKER_SECRET is not set: all POST/DELETE endpoints are unauthenticated")
+    _wait_for_display()
 
     # Kill any stale Dolphin instance left from a previous broker run.
     # -x matches the process name exactly; -f with a path substring would also
@@ -1656,7 +1816,7 @@ def main():
     _patch_ini()
 
     # Clean up any leftover selkies socket files from a previous container run.
-    # Only done once at startup — not on game launches, where webrtc_input is
+    # Only done once at startup, not on game launches, where webrtc_input is
     # already running and manages its own socket lifecycle.
     _cleanup_stale_sockets()
 

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -12,6 +12,7 @@ import signal
 import socket as _socket
 import subprocess
 import sys
+import tempfile
 import time
 import zipfile
 from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
@@ -416,7 +417,12 @@ def _spawn_dolphin(rom_path, state_path=None):
             cmd,
             stdout=log_fh if log_fh else subprocess.DEVNULL,
             stderr=subprocess.STDOUT if log_fh else subprocess.DEVNULL,
-            preexec_fn=os.setpgrp,
+            # start_new_session, not preexec_fn=os.setpgrp: this process runs a
+            # ThreadingHTTPServer, and a preexec_fn runs between fork and exec
+            # in a threaded parent, where it can deadlock on a lock another
+            # thread held at fork time. setsid gives the same killable process
+            # group without running Python in the child.
+            start_new_session=True,
         )
     except Exception as exc:
         log.error("Failed to launch Dolphin: %s", exc)
@@ -443,31 +449,35 @@ def _monitor_process(proc, start_time):
     proc.wait()
     duration = time.monotonic() - start_time
 
-    with _session_lock:
-        should_relaunch = _session["is_managed"] and _session["process"] is proc
-
-    if not should_relaunch:
-        return
-
     # A dashboard that dies immediately dies again on relaunch, so back off and
     # eventually stop: an uncapped loop respawned a broken Dolphin forever and
     # buried the reason under thousands of identical log lines.
-    if duration >= RELAUNCH_HEALTHY_SECONDS:
-        failures = 0
-        wait_time = 1
-    else:
-        with _session_lock:
-            failures = _session["relaunch_failures"] + 1
-        if failures > RELAUNCH_MAX_FAILURES:
-            log.error(
-                "Dolphin exited after %.1fs on %d consecutive relaunches, giving up",
-                duration, failures - 1,
-            )
-            with _session_lock:
-                _session["is_managed"] = False
-                _session["relaunch_failures"] = 0
+    #
+    # The counter is read, incremented and stored under one lock acquisition,
+    # before the backoff sleep. Committing it after the sleep let a second
+    # monitor thread (a relaunch that died while this one waited) read the old
+    # value, so two crash loops each counted from zero and neither gave up.
+    with _session_lock:
+        if not (_session["is_managed"] and _session["process"] is proc):
             return
-        wait_time = min(RELAUNCH_BACKOFF_CAP, RELAUNCH_BACKOFF_BASE * 2 ** (failures - 1))
+        if duration >= RELAUNCH_HEALTHY_SECONDS:
+            failures = _session["relaunch_failures"] = 0
+            wait_time = 1
+        else:
+            failures = _session["relaunch_failures"] = _session["relaunch_failures"] + 1
+            wait_time = min(
+                RELAUNCH_BACKOFF_CAP, RELAUNCH_BACKOFF_BASE * 2 ** (failures - 1)
+            )
+
+    if failures > RELAUNCH_MAX_FAILURES:
+        log.error(
+            "Dolphin exited after %.1fs on %d consecutive relaunches, giving up",
+            duration, RELAUNCH_MAX_FAILURES,
+        )
+        with _session_lock:
+            _session["is_managed"] = False
+            _session["relaunch_failures"] = 0
+        return
 
     log.info("Dolphin exited after %.1fs, relaunching dashboard in %ds", duration, wait_time)
     time.sleep(wait_time)
@@ -475,7 +485,6 @@ def _monitor_process(proc, start_time):
     with _session_lock:
         if not _session["is_managed"]:
             return
-        _session["relaunch_failures"] = failures
 
     _launch_dolphin(None)
 
@@ -728,15 +737,24 @@ def _wait_for_sstate_write(state_dir: Path, before: dict, deadline: float, slot:
 
 STATE_FILE_MAX_BYTES = 256 * 1024 * 1024
 STATE_GET_WAIT = float(os.environ.get("STATE_GET_WAIT", "30.0"))
+# Transfers move through the socket and the filesystem in chunks this size, so
+# a request costs a fixed amount of memory instead of its whole payload.
+_STREAM_CHUNK = 1024 * 1024
 
 
-def _wait_for_save_idle(deadline: float) -> None:
-    """Block until no save is in flight, or the deadline passes."""
+def _wait_for_save_idle(deadline: float) -> bool:
+    """Block until no save is in flight. False if the deadline passed first.
+
+    The caller needs to tell "the save finished" from "we gave up waiting":
+    returning nothing made both look identical, so a timeout silently served
+    whatever half-written file happened to be on disk.
+    """
     while time.monotonic() < deadline:
         with _session_lock:
             if not _session["save_in_progress"]:
-                return
+                return True
         time.sleep(0.2)
+    return False
 
 
 def _newest_state_for_slot(slot: int) -> Path | None:
@@ -882,24 +900,56 @@ def _save_data_root() -> Path | None:
     return None
 
 
+def _walk_regular_files(base: Path) -> list[Path]:
+    """Every regular file under base, never crossing a symlink.
+
+    os.walk (which does not follow directory symlinks), not rglob: rglob
+    descends into symlinked directories, so a link planted under the tree would
+    pull an arbitrary part of the filesystem into an archive.
+    """
+    if base.is_symlink() or not base.is_dir():
+        return []
+    files: list[Path] = []
+    for dirpath, _dirnames, filenames in os.walk(base):
+        for name in filenames:
+            p = Path(dirpath, name)
+            if p.is_file() and not p.is_symlink():
+                files.append(p)
+    return files
+
+
 def _iter_save_files(root: Path) -> list[Path]:
     """Every regular file under the allowed save subtrees, sorted for a
     deterministic archive (identical content zips to identical bytes).
-
-    os.walk, not rglob: rglob descends into symlinked directories, so a link
-    planted under GC/ would pull an arbitrary tree into the archive.
     """
     files: list[Path] = []
     for sub in SAVE_SYNC_SUBTREES:
-        base = root / sub
-        if base.is_symlink() or not base.is_dir():
-            continue
-        for dirpath, _dirnames, filenames in os.walk(base):
-            for name in filenames:
-                p = Path(dirpath, name)
-                if p.is_file() and not p.is_symlink():
-                    files.append(p)
+        files.extend(_walk_regular_files(root / sub))
     return sorted(files)
+
+
+def _open_archive(source: bytes | Path) -> zipfile.ZipFile:
+    """Open a pulled archive from memory or from a spooled temp file."""
+    return zipfile.ZipFile(io.BytesIO(source) if isinstance(source, bytes) else source)
+
+
+def _read_member(zf: zipfile.ZipFile, info: zipfile.ZipInfo, budget: int) -> bytes:
+    """Decompress one member, refusing to produce more than `budget` bytes.
+
+    info.file_size is the archive's own claim about the member and a crafted
+    zip can understate it by orders of magnitude, so the declared-size total is
+    only a cheap first pass: the actual read is capped and checked. Raises
+    ValueError when the member overruns or when the member itself is corrupt,
+    so one bad entry is reported as a rejected archive and not as a 500.
+    """
+    try:
+        with zf.open(info) as fh:
+            data = fh.read(budget + 1)
+    except zipfile.BadZipFile as exc:
+        raise ValueError(f"archive member {info.filename} is corrupt: {exc}") from exc
+    if len(data) > budget:
+        raise ValueError(f"archive member {info.filename} exceeds the size limit")
+    return data
 
 
 def _build_save_archive(baseline: float) -> bytes | None:
@@ -953,7 +1003,7 @@ def _mkdirs_owned(path: Path) -> None:
             pass
 
 
-def _extract_save_archive(content: bytes) -> tuple[int, int] | str:
+def _extract_save_archive(source: bytes | Path) -> tuple[int, int] | str:
     """Restore a pulled save archive into the data dir.
 
     Returns (written, skipped) on success, or an error string for a bad
@@ -965,13 +1015,14 @@ def _extract_save_archive(content: bytes) -> tuple[int, int] | str:
     save tree half restored, with no record of which half."""
     root = _save_data_root() or _SAVE_DATA_ROOTS[0]
     try:
-        zf = zipfile.ZipFile(io.BytesIO(content))
+        zf = _open_archive(source)
     except zipfile.BadZipFile:
         return "body is not a zip archive"
     with zf:
         infos = [i for i in zf.infolist() if not i.is_dir()]
         if sum(i.file_size for i in infos) > SAVE_FILE_MAX_BYTES:
             return "archive exceeds size limit when extracted"
+        budget = SAVE_FILE_MAX_BYTES
         for info in infos:
             member = PurePosixPath(info.filename)
             if member.is_absolute() or ".." in member.parts:
@@ -993,12 +1044,14 @@ def _extract_save_archive(content: bytes) -> tuple[int, int] | str:
                 ):
                     skipped += 1
                     continue
+                data = _read_member(zf, info, budget)
+                budget -= len(data)
                 _mkdirs_owned(target.parent)
                 tmp = target.parent / f".{target.name}.tmp"
-                tmp.write_bytes(zf.read(info))
+                tmp.write_bytes(data)
                 os.chown(tmp, _LOG_UID, _LOG_GID)
                 staged.append((tmp, target, mtime))
-        except OSError as exc:
+        except (OSError, ValueError) as exc:
             for tmp, _target, _mtime in staged:
                 try:
                     tmp.unlink()
@@ -1045,7 +1098,7 @@ def _screenshot_snapshot(root: Path) -> set:
     """Every PNG currently under the ScreenShots tree, one game dir per title."""
     if not root.is_dir():
         return set()
-    return {p for p in root.rglob("*.png") if p.is_file()}
+    return {p for p in _walk_regular_files(root) if p.suffix.lower() == ".png"}
 
 
 def _capture_state_screenshot(wid: str, slot: int) -> bool:
@@ -1126,7 +1179,7 @@ def _build_memory_card_archive() -> bytes | None | str:
         return "slot A card path is a file; a GCI folder is required"
     if not path.is_dir():
         return None
-    files = [p for p in sorted(path.rglob("*")) if p.is_file() and not p.is_symlink()]
+    files = sorted(_walk_regular_files(path))
     total = 0
     for p in files:
         try:
@@ -1146,12 +1199,32 @@ def _build_memory_card_archive() -> bytes | None | str:
     return buf.getvalue()
 
 
-def _replace_memory_card(content: bytes) -> tuple[int] | str:
+def _replace_memory_card(source: bytes | Path) -> tuple[int] | str:
     with _memory_card_lock:
-        return _replace_memory_card_locked(content)
+        return _replace_memory_card_locked(source)
 
 
-def _replace_memory_card_locked(content: bytes) -> tuple[int] | str:
+def _recover_memory_card() -> None:
+    """Put the slot-A card back if a previous run died mid-swap.
+
+    _replace_memory_card_locked moves the live card aside to `.Card A.old`
+    before moving the staged one into place. A crash or container stop inside
+    that window leaves no card at all, and the backup is then the only copy of
+    the user's saves, so it is reclaimed on the next boot rather than sitting
+    there as a dotfile nobody looks for.
+    """
+    path = _gci_card_path()
+    backup = path.parent / f".{path.name}.old"
+    if path.exists() or not backup.is_dir():
+        return
+    try:
+        os.replace(backup, path)
+        log.warning("memory-card: restored slot-A card from %s after an interrupted swap", backup)
+    except OSError as exc:
+        log.error("memory-card: could not restore %s from %s: %s", path, backup, exc)
+
+
+def _replace_memory_card_locked(source: bytes | Path) -> tuple[int] | str:
     """Wipe the Slot-A card and lay down the pulled card image. Returns
     (written,) on success or an error string. The whole card is replaced (no
     per-file mtime merge): this is the hydrate-with-isolation guarantee for
@@ -1162,13 +1235,14 @@ def _replace_memory_card_locked(content: bytes) -> tuple[int] | str:
         log.warning("memory-card: hydrate rejected, slot A path is a file at %s", path)
         return "slot A card path is a file; a GCI folder is required"
     try:
-        zf = zipfile.ZipFile(io.BytesIO(content))
+        zf = _open_archive(source)
     except zipfile.BadZipFile:
         return "body is not a zip archive"
     with zf:
         infos = [i for i in zf.infolist() if not i.is_dir()]
         if sum(i.file_size for i in infos) > SAVE_FILE_MAX_BYTES:
             return "archive exceeds size limit when extracted"
+        budget = SAVE_FILE_MAX_BYTES
         for info in infos:
             member = PurePosixPath(info.filename)
             if member.is_absolute() or ".." in member.parts:
@@ -1183,9 +1257,11 @@ def _replace_memory_card_locked(content: bytes) -> tuple[int] | str:
             written = 0
             for info in infos:
                 target = staging / PurePosixPath(info.filename)
+                data = _read_member(zf, info, budget)
+                budget -= len(data)
                 _mkdirs_owned(target.parent)
                 tmp = target.parent / f".{target.name}.tmp"
-                tmp.write_bytes(zf.read(info))
+                tmp.write_bytes(data)
                 os.chown(tmp, _LOG_UID, _LOG_GID)
                 os.replace(tmp, target)
                 written += 1
@@ -1195,7 +1271,7 @@ def _replace_memory_card_locked(content: bytes) -> tuple[int] | str:
             if path.exists():
                 os.replace(path, backup)
             os.replace(staging, path)
-        except OSError as exc:
+        except (OSError, ValueError) as exc:
             shutil.rmtree(staging, ignore_errors=True)
             # If we moved the old card aside but never put the new one in place,
             # restore it so a mid-swap failure never leaves the user cardless.
@@ -1264,6 +1340,46 @@ class BrokerHandler(BaseHTTPRequestHandler):
             return None
         return body
 
+    def _spool_body(self, limit: int):
+        """Stream the request body to a temp file, or None once an error is sent.
+
+        Returns the path to a spooled copy the caller must unlink. Bodies used
+        to be read into one bytes object and then handed to zipfile, so a single
+        upload cost twice its size in memory and a handful of concurrent ones
+        could exhaust the container.
+        """
+        try:
+            length = int(self.headers.get("Content-Length", 0))
+        except ValueError:
+            length = 0
+        if length <= 0:
+            self._send_json(400, {"error": "missing or empty body"})
+            return None
+        if length > limit:
+            self._send_json(413, {"error": "archive too large"})
+            return None
+
+        fd, name = tempfile.mkstemp(prefix=".broker-upload-")
+        path = Path(name)
+        remaining = length
+        try:
+            with os.fdopen(fd, "wb") as out:
+                while remaining > 0:
+                    chunk = self.rfile.read(min(_STREAM_CHUNK, remaining))
+                    if not chunk:
+                        break
+                    out.write(chunk)
+                    remaining -= len(chunk)
+        except OSError as exc:
+            path.unlink(missing_ok=True)
+            self._send_json(500, {"error": f"could not buffer request body: {exc}"})
+            return None
+        if remaining:
+            path.unlink(missing_ok=True)
+            self._send_json(400, {"error": "truncated request body"})
+            return None
+        return path
+
     def _get_state_file(self):
         query = parse_qs(urlparse(self.path).query)
         try:
@@ -1278,8 +1394,13 @@ class BrokerHandler(BaseHTTPRequestHandler):
             return
 
         # Block while a save is being written so the caller never receives a
-        # half-written or stale file right after triggering a save.
-        _wait_for_save_idle(time.monotonic() + STATE_GET_WAIT)
+        # half-written or stale file right after triggering a save. A save that
+        # is still running at the deadline is reported rather than served: the
+        # file on disk is mid-flush and RomM must not store it as the state.
+        if not _wait_for_save_idle(time.monotonic() + STATE_GET_WAIT):
+            log.warning("state-file: save still in progress after %.1fs, refusing to serve", STATE_GET_WAIT)
+            self._send_json(409, {"error": "save still in progress", "slot": slot})
+            return
 
         state_path = _newest_state_for_slot(slot)
         if state_path is None:
@@ -1288,23 +1409,37 @@ class BrokerHandler(BaseHTTPRequestHandler):
         try:
             # Size first: reading then measuring would pull an oversized state
             # entirely into memory only to refuse it.
-            if state_path.stat().st_size > STATE_FILE_MAX_BYTES:
+            size = state_path.stat().st_size
+            if size > STATE_FILE_MAX_BYTES:
                 self._send_json(413, {"error": "state file exceeds size limit"})
                 return
-            content = state_path.read_bytes()
+            fh = state_path.open("rb")
         except OSError as exc:
             self._send_json(500, {"error": f"could not read state file: {exc}"})
             return
-        if len(content) > STATE_FILE_MAX_BYTES:
-            self._send_json(413, {"error": "state file exceeds size limit"})
-            return
+
+        # Streamed in chunks rather than read_bytes(): states run to hundreds of
+        # megabytes and this is a threaded server, so buffering whole files here
+        # multiplied the limit by however many callers were pulling at once.
         self.send_response(200)
         self.send_header("Content-Type", "application/octet-stream")
-        self.send_header("Content-Length", str(len(content)))
+        self.send_header("Content-Length", str(size))
         self.send_header("X-State-Filename", state_path.name)
         self.end_headers()
-        self.wfile.write(content)
-        log.info("state-file: served %s (%d bytes)", state_path.name, len(content))
+        sent = 0
+        with fh:
+            while sent < size:
+                chunk = fh.read(min(_STREAM_CHUNK, size - sent))
+                if not chunk:
+                    break
+                self.wfile.write(chunk)
+                sent += len(chunk)
+        if sent != size:
+            # The body is already short; the connection is the only signal left.
+            log.error("state-file: %s shrank mid-send (%d of %d bytes)", state_path.name, sent, size)
+            self.close_connection = True
+            return
+        log.info("state-file: served %s (%d bytes)", state_path.name, sent)
 
     def _get_state_screenshot(self):
         query = parse_qs(urlparse(self.path).query)
@@ -1321,7 +1456,10 @@ class BrokerHandler(BaseHTTPRequestHandler):
 
         # A save in flight is about to overwrite this slot's thumbnail; wait it
         # out so the caller never pairs a new state with the previous frame.
-        _wait_for_save_idle(time.monotonic() + STATE_GET_WAIT)
+        if not _wait_for_save_idle(time.monotonic() + STATE_GET_WAIT):
+            log.warning("state-screenshot: save still in progress after %.1fs, refusing to serve", STATE_GET_WAIT)
+            self._send_json(409, {"error": "save still in progress", "slot": slot})
+            return
 
         path = _state_shot_path(slot)
         try:
@@ -1374,21 +1512,13 @@ class BrokerHandler(BaseHTTPRequestHandler):
         log.info("save-file: served archive (%d bytes)", len(archive))
 
     def _put_save_file(self):
+        spooled = self._spool_body(SAVE_FILE_MAX_BYTES)
+        if spooled is None:
+            return
         try:
-            length = int(self.headers.get("Content-Length", 0))
-        except ValueError:
-            length = 0
-        if length <= 0:
-            self._send_json(400, {"error": "missing or empty body"})
-            return
-        if length > SAVE_FILE_MAX_BYTES:
-            self._send_json(413, {"error": "archive too large"})
-            return
-        content = self.rfile.read(length)
-        if len(content) != length:
-            self._send_json(400, {"error": "truncated request body"})
-            return
-        result = _extract_save_archive(content)
+            result = _extract_save_archive(spooled)
+        finally:
+            spooled.unlink(missing_ok=True)
         if isinstance(result, str):
             self._send_json(400, {"error": result})
             return
@@ -1420,21 +1550,13 @@ class BrokerHandler(BaseHTTPRequestHandler):
         log.info("memory-card: served slot-A card (%d bytes)", len(result))
 
     def _put_memory_card(self):
+        spooled = self._spool_body(SAVE_FILE_MAX_BYTES)
+        if spooled is None:
+            return
         try:
-            length = int(self.headers.get("Content-Length", 0))
-        except ValueError:
-            length = 0
-        if length <= 0:
-            self._send_json(400, {"error": "missing or empty body"})
-            return
-        if length > SAVE_FILE_MAX_BYTES:
-            self._send_json(413, {"error": "archive too large"})
-            return
-        content = self.rfile.read(length)
-        if len(content) != length:
-            self._send_json(400, {"error": "truncated request body"})
-            return
-        result = _replace_memory_card(content)
+            result = _replace_memory_card(spooled)
+        finally:
+            spooled.unlink(missing_ok=True)
         if isinstance(result, str):
             self._send_json(400, {"error": result})
             return
@@ -1471,6 +1593,11 @@ class BrokerHandler(BaseHTTPRequestHandler):
         ):
             self._send_json(400, {"error": "filename must be a <GameID>.sNN basename"})
             return
+        # The slot in the name is bounded here too. Accepting any .sNN let a
+        # caller write .s99, a slot no other route will read back or overwrite.
+        if not (1 <= int(ext[1:]) <= MAX_SLOT):
+            self._send_json(400, {"error": f"filename slot must be 01-{MAX_SLOT:02d}"})
+            return
 
         try:
             length = int(self.headers.get("Content-Length", 0))
@@ -1482,16 +1609,25 @@ class BrokerHandler(BaseHTTPRequestHandler):
         if length > STATE_FILE_MAX_BYTES:
             self._send_json(413, {"error": "state file exceeds size limit"})
             return
-        content = self.rfile.read(length)
-        if len(content) != length:
-            self._send_json(400, {"error": "truncated request body"})
-            return
-
         state_dir = _sstate_dir() or _SSTATE_DIR_CANDIDATES[0]
         tmp = state_dir / f".{filename}.tmp"
+        remaining = length
         try:
             state_dir.mkdir(parents=True, exist_ok=True)
-            tmp.write_bytes(content)
+            # Streamed straight into the temp file: a state is up to
+            # STATE_FILE_MAX_BYTES and buffering it whole put that much per
+            # concurrent upload on the heap before anything touched disk.
+            with tmp.open("wb") as out:
+                while remaining > 0:
+                    chunk = self.rfile.read(min(_STREAM_CHUNK, remaining))
+                    if not chunk:
+                        break
+                    out.write(chunk)
+                    remaining -= len(chunk)
+            if remaining:
+                tmp.unlink(missing_ok=True)
+                self._send_json(400, {"error": "truncated request body"})
+                return
             # Dolphin runs as abc and must be able to overwrite the slot later.
             os.chown(tmp, _LOG_UID, _LOG_GID)
             os.replace(tmp, state_dir / filename)
@@ -1672,6 +1808,12 @@ class BrokerHandler(BaseHTTPRequestHandler):
                 if _session["rom_path"] is None:
                     self._send_json(409, {"error": "no game is running"})
                     return
+                # Loading mid-save races the save it would overwrite, the same
+                # way every other slot route does; this one used to skip the
+                # check and could roll the player back onto a stale state.
+                if _session["save_in_progress"]:
+                    self._send_json(409, {"error": "save already in progress"})
+                    return
             body = self._read_body()
             if body is None:
                 return
@@ -1787,14 +1929,15 @@ def _graceful_shutdown(server: HTTPServer, signum: int) -> None:
     log.info("Received signal %d, beginning graceful shutdown", signum)
     Thread(target=server.shutdown, daemon=True).start()
 
-    deadline = time.monotonic() + max(SSTATE_WAIT, 5.0)
+    grace = max(SSTATE_WAIT, 5.0)
+    deadline = time.monotonic() + grace
     while time.monotonic() < deadline:
         with _session_lock:
             if not _session["save_in_progress"]:
                 break
         time.sleep(0.2)
     else:
-        log.warning("Shutdown: in-flight save did not complete within %.1fs, killing Dolphin anyway", SSTATE_WAIT)
+        log.warning("Shutdown: in-flight save did not complete within %.1fs, killing Dolphin anyway", grace)
 
     _kill_dolphin()
     log.info("Shutdown complete")
@@ -1812,6 +1955,11 @@ def main():
     if result.returncode == 0:
         log.info("Killed stale dolphin-emu instance(s) on startup.")
         _wait_dolphin_gone()
+
+    # Before _patch_ini: the ini pins GCIFolderAPathOverride at the card path,
+    # and a card left stranded by an interrupted swap should be back in place
+    # before Dolphin is ever pointed at it.
+    _recover_memory_card()
 
     _patch_ini()
 

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -7,6 +7,7 @@ import io
 import json
 import logging
 import os
+import shutil
 import signal
 import socket as _socket
 import subprocess
@@ -43,6 +44,9 @@ _SSTATE_DIR_CANDIDATES = (
     Path("/config/.local/share/dolphin-emu/StateSaves"),
     Path("/config/.config/dolphin-emu/StateSaves"),
 )
+
+# Dolphin's EXIDeviceType for a GCI folder card (Source/Core/Core/HW/EXI/EXI_Device.h).
+EXI_MEMORY_CARD_FOLDER = 8
 
 ENV = {
     "DISPLAY":            ":0",
@@ -132,6 +136,7 @@ def _patch_ini(fullscreen: bool = False):
         return
 
     fs_val = "True" if fullscreen else "False"
+    card_dir = str(_gci_card_path())
 
     if not INI_PATH.exists():
         try:
@@ -146,6 +151,8 @@ def _patch_ini(fullscreen: bool = False):
                 "SIDevice3 = 0\n"
                 "GFXBackend = OpenGL\n"
                 "CPUThread = False\n"
+                f"SlotA = {EXI_MEMORY_CARD_FOLDER}\n"
+                f"GCIFolderAPathOverride = {card_dir}\n"
                 "\n"
                 "[Interface]\n"
                 "ConfirmStop = False\n"
@@ -176,6 +183,8 @@ def _patch_ini(fullscreen: bool = False):
             "SIDevice3": "0",
             "GFXBackend": "OpenGL",
             "CPUThread": "False",
+            "SlotA": str(EXI_MEMORY_CARD_FOLDER),
+            "GCIFolderAPathOverride": card_dir,
         },
         "Interface": {"ConfirmStop": "False"},
         "Display": {"RenderToMain": "False", "Fullscreen": fs_val},
@@ -755,7 +764,10 @@ _SAVE_DATA_ROOTS = (
 )
 # Archive members must live under one of these root-relative subtrees; PUT
 # rejects anything else so a crafted zip cannot reach configs, keys or states.
-SAVE_SYNC_SUBTREES = ("GC", "Wii/title")
+# The Slot-A card is listed so GameCube saves still round-trip on a container
+# that has not opted in to whole-card sync; RomM skips /save-file entirely on
+# one that has, so the two paths never both carry the card.
+SAVE_SYNC_SUBTREES = ("GC", "Wii/title", "romm/Card A")
 SAVE_FILE_MAX_BYTES = 256 * 1024 * 1024
 # Zip stores mtimes at 2 s DOS resolution; the slack keeps the newer-file
 # guard from skipping files over rounding alone.
@@ -960,6 +972,120 @@ def _capture_state_screenshot(wid: str, slot: int) -> bool:
     return True
 
 
+# ── Memory cards ──────────────────────────────────────────────────────────────
+# RomM syncs the GameCube Slot-A card as one whole image, so a user's card can be
+# hydrated onto any pooled container. GET evacuates the card, PUT wipes it and
+# lays the pulled one back down. Slot B is never touched.
+#
+# Dolphin's default GCI folder sits under a region directory it picks from the
+# booted game (GC/USA/Card A), which the broker cannot know before launch. Slot A
+# is therefore pinned to GCIFolderAPathOverride, which Dolphin uses verbatim with
+# no region or card-name parts appended, giving one stable card dir per container.
+
+
+def _gci_card_path() -> Path:
+    """Absolute path to the Slot-A GCI folder card, existence-independent."""
+    env = os.environ.get("GCI_CARD_DIR")
+    if env:
+        return Path(env)
+    return (_save_data_root() or _SAVE_DATA_ROOTS[0]) / "romm" / "Card A"
+
+
+def _build_memory_card_archive() -> bytes | None | str:
+    """Zip the whole Slot-A card, member paths relative to the card root so the
+    image is path independent. Returns the zip bytes, None when the card dir does
+    not exist yet, or an error string when it is not a directory."""
+    path = _gci_card_path()
+    if path.exists() and not path.is_dir():
+        return "slot A card path is a file; a GCI folder is required"
+    if not path.is_dir():
+        return None
+    files = [p for p in sorted(path.rglob("*")) if p.is_file() and not p.is_symlink()]
+    total = 0
+    for p in files:
+        try:
+            total += p.stat().st_size
+        except OSError:
+            continue
+    if total > SAVE_FILE_MAX_BYTES:
+        log.warning("memory-card: card exceeds size limit (%d bytes)", total)
+        return "memory card exceeds size limit"
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for p in files:
+            try:
+                zf.write(p, p.relative_to(path).as_posix())
+            except OSError as exc:
+                log.warning("memory-card: could not read %s: %s", p, exc)
+    return buf.getvalue()
+
+
+def _replace_memory_card(content: bytes) -> tuple[int] | str:
+    """Wipe the Slot-A card and lay down the pulled card image. Returns
+    (written,) on success or an error string. The whole card is replaced (no
+    per-file mtime merge): this is the hydrate-with-isolation guarantee for
+    pooled containers. Extraction goes to a staging dir that is swapped over the
+    live card, so a mid-way failure never leaves a half-wiped card."""
+    path = _gci_card_path()
+    if path.exists() and not path.is_dir():
+        log.warning("memory-card: hydrate rejected, slot A path is a file at %s", path)
+        return "slot A card path is a file; a GCI folder is required"
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(content))
+    except zipfile.BadZipFile:
+        return "body is not a zip archive"
+    with zf:
+        infos = [i for i in zf.infolist() if not i.is_dir()]
+        if sum(i.file_size for i in infos) > SAVE_FILE_MAX_BYTES:
+            return "archive exceeds size limit when extracted"
+        for info in infos:
+            member = PurePosixPath(info.filename)
+            if member.is_absolute() or ".." in member.parts:
+                return f"archive member escapes card dir: {info.filename}"
+
+        parent = path.parent
+        staging = parent / f".{path.name}.new-{os.getpid()}"
+        backup = parent / f".{path.name}.old-{os.getpid()}"
+        shutil.rmtree(staging, ignore_errors=True)
+        try:
+            _mkdirs_owned(staging)
+            written = 0
+            for info in infos:
+                target = staging / PurePosixPath(info.filename)
+                _mkdirs_owned(target.parent)
+                tmp = target.parent / f".{target.name}.tmp"
+                tmp.write_bytes(zf.read(info))
+                os.chown(tmp, _LOG_UID, _LOG_GID)
+                os.replace(tmp, target)
+                written += 1
+            # Swap staging over the live card: move the old card aside, move the
+            # new one into place, then drop the old. Both live under the same
+            # parent, so the renames are atomic same-filesystem operations.
+            if path.exists():
+                os.replace(path, backup)
+            os.replace(staging, path)
+        except OSError as exc:
+            shutil.rmtree(staging, ignore_errors=True)
+            # If we moved the old card aside but never put the new one in place,
+            # restore it so a mid-swap failure never leaves the user cardless.
+            if not path.exists() and backup.exists():
+                try:
+                    os.replace(backup, path)
+                except OSError:
+                    # The backup is now the only surviving copy of the card,
+                    # leave it on disk for manual recovery instead of deleting it.
+                    log.error(
+                        "memory-card: could not restore card to %s, old card preserved at %s",
+                        path,
+                        backup,
+                    )
+                    return f"could not write memory card: {exc}"
+            shutil.rmtree(backup, ignore_errors=True)
+            return f"could not write memory card: {exc}"
+        shutil.rmtree(backup, ignore_errors=True)
+    return (written,)
+
+
 # ── HTTP handler ──────────────────────────────────────────────────────────────
 
 class BrokerHandler(BaseHTTPRequestHandler):
@@ -975,11 +1101,13 @@ class BrokerHandler(BaseHTTPRequestHandler):
             SECRET,
         )
 
-    def _send_json(self, code: int, body: dict) -> None:
+    def _send_json(self, code: int, body: dict, headers: dict | None = None) -> None:
         payload = json.dumps(body).encode()
         self.send_response(code)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(payload)))
+        for name, value in (headers or {}).items():
+            self.send_header(name, value)
         self.end_headers()
         self.wfile.write(payload)
 
@@ -1108,6 +1236,52 @@ class BrokerHandler(BaseHTTPRequestHandler):
         log.info("save-file: restored archive — %d written, %d skipped", written, skipped)
         self._send_json(200, {"status": "ok", "written": written, "skipped": skipped})
 
+    def _get_memory_card(self):
+        result = _build_memory_card_archive()
+        if isinstance(result, str):
+            self._send_json(409, {"error": result})
+            return
+        if result is None:
+            # Tag the "no card yet" 404 so the backend can tell a genuinely
+            # empty card apart from a missing endpoint (an unmarked 404), which
+            # must NOT be treated as safe-to-wipe.
+            self._send_json(
+                404,
+                {"error": "no folder memory card in slot A"},
+                headers={"X-Memory-Card": "absent"},
+            )
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "application/zip")
+        self.send_header("Content-Length", str(len(result)))
+        self.send_header("X-Memory-Card-Slot", "A")
+        self.end_headers()
+        self.wfile.write(result)
+        log.info("memory-card: served slot-A card (%d bytes)", len(result))
+
+    def _put_memory_card(self):
+        try:
+            length = int(self.headers.get("Content-Length", 0))
+        except ValueError:
+            length = 0
+        if length <= 0:
+            self._send_json(400, {"error": "missing or empty body"})
+            return
+        if length > SAVE_FILE_MAX_BYTES:
+            self._send_json(413, {"error": "archive too large"})
+            return
+        content = self.rfile.read(length)
+        if len(content) != length:
+            self._send_json(400, {"error": "truncated request body"})
+            return
+        result = _replace_memory_card(content)
+        if isinstance(result, str):
+            self._send_json(400, {"error": result})
+            return
+        (written,) = result
+        log.info("memory-card: replaced slot-A card — %d files", written)
+        self._send_json(200, {"status": "ok", "written": written})
+
     def do_PUT(self):
         if not self._check_secret():
             self._send_json(403, {"error": "forbidden"})
@@ -1115,6 +1289,9 @@ class BrokerHandler(BaseHTTPRequestHandler):
         parsed = urlparse(self.path)
         if parsed.path == "/save-file":
             self._put_save_file()
+            return
+        if parsed.path == "/memory-card":
+            self._put_memory_card()
             return
         if parsed.path != "/state-file":
             self._send_json(404, {"error": "not found"})
@@ -1179,6 +1356,8 @@ class BrokerHandler(BaseHTTPRequestHandler):
             self._get_state_file()
         elif urlparse(self.path).path == "/save-file":
             self._get_save_file()
+        elif urlparse(self.path).path == "/memory-card":
+            self._get_memory_card()
         elif urlparse(self.path).path == "/state-screenshot":
             self._get_state_screenshot()
         elif self.path == "/status":

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -112,6 +112,11 @@ _launch_lock = Lock()
 # Serialises card hydration. The staging and backup dirs were named after the
 # pid, which is the same pid for every thread of this server.
 _memory_card_lock = Lock()
+# Guards the save tree. Every restore stages into the same directory and wipes
+# it on entry, so two concurrent PUT /save-file deleted each other's staged
+# members and then renamed paths that were no longer there. GET /save-file
+# takes it too, or it zips a tree caught halfway through a restore's renames.
+_save_file_lock = Lock()
 _session: dict = {
     "process":          None,
     "rom_path":         None,
@@ -483,7 +488,11 @@ def _monitor_process(proc, start_time):
     time.sleep(wait_time)
 
     with _session_lock:
-        if not _session["is_managed"]:
+        # The process check is repeated, not just is_managed: a /launch landing
+        # during a backoff sleep installs a new process, and a monitor that only
+        # rechecked the flag went on to relaunch the dashboard over the game the
+        # user had just started.
+        if not (_session["is_managed"] and _session["process"] is proc):
             return
 
     _launch_dolphin(None)
@@ -740,6 +749,40 @@ STATE_GET_WAIT = float(os.environ.get("STATE_GET_WAIT", "30.0"))
 # Transfers move through the socket and the filesystem in chunks this size, so
 # a request costs a fixed amount of memory instead of its whole payload.
 _STREAM_CHUNK = 1024 * 1024
+# Where uploads are spooled. Under /config, the mounted volume, rather than the
+# system temp dir: /tmp in this image holds the selkies sockets and is sized for
+# nothing, and a 256 MB upload landing there fills it out from under the stream.
+SPOOL_DIR_DEFAULT = "/config/.romm-broker-spool"
+
+
+def _spool_dir() -> str | None:
+    """The spool dir if it can be created, else None for the system default."""
+    path = Path(os.environ.get("BROKER_SPOOL_DIR", SPOOL_DIR_DEFAULT))
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+        return str(path)
+    except OSError as exc:
+        log.warning("spool: cannot use %s (%s), falling back to the system temp dir",
+                    path, exc)
+        return None
+
+
+def _clear_spool() -> None:
+    """Drop uploads left spooled by a previous run.
+
+    A container killed mid-PUT leaves a partial archive behind; nothing reads
+    them back, so they are dead weight on the user's volume until removed.
+    """
+    # The fallback location is swept too. That is the case where clearing
+    # matters most: an unusable /config means every upload has been landing in
+    # the system temp dir, where nothing else prunes them either.
+    directory = _spool_dir() or tempfile.gettempdir()
+    for stale in Path(directory).glob(".broker-upload-*"):
+        try:
+            stale.unlink()
+            log.info("spool: removed stale upload %s", stale.name)
+        except OSError:
+            pass
 
 
 def _wait_for_save_idle(deadline: float) -> bool:
@@ -884,6 +927,10 @@ def _restart_selkies():
 # one that has, so the two paths never both carry the card.
 SAVE_SYNC_SUBTREES = ("GC", "Wii/title", "romm/Card A")
 SAVE_FILE_MAX_BYTES = 256 * 1024 * 1024
+# Where a restore stages members before renaming them into place. Root-relative
+# and deliberately outside SAVE_SYNC_SUBTREES, so a staging dir left behind by
+# a crash is never picked up as a save and shipped back to RomM.
+RESTORE_STAGING_DIR = ".romm-restore"
 # Zip stores mtimes at 2 s DOS resolution; the slack keeps the newer-file
 # guard from skipping files over rounding alone.
 _SAVE_MTIME_SLACK = 2.0
@@ -933,23 +980,44 @@ def _open_archive(source: bytes | Path) -> zipfile.ZipFile:
     return zipfile.ZipFile(io.BytesIO(source) if isinstance(source, bytes) else source)
 
 
-def _read_member(zf: zipfile.ZipFile, info: zipfile.ZipInfo, budget: int) -> bytes:
-    """Decompress one member, refusing to produce more than `budget` bytes.
+def _extract_member(
+    zf: zipfile.ZipFile, info: zipfile.ZipInfo, dest: Path, budget: int
+) -> int:
+    """Decompress one member into `dest`, writing at most `budget` bytes.
 
     info.file_size is the archive's own claim about the member and a crafted
     zip can understate it by orders of magnitude, so the declared-size total is
-    only a cheap first pass: the actual read is capped and checked. Raises
-    ValueError when the member overruns or when the member itself is corrupt,
-    so one bad entry is reported as a rejected archive and not as a 500.
+    only a cheap first pass: the actual write is capped and checked.
+
+    Copied a chunk at a time rather than read() into one buffer: a member is
+    allowed to be as large as the whole archive limit, and holding that on the
+    heap would undo the spooling the request body already went through.
+
+    Raises ValueError for anything the archive itself is responsible for (an
+    overrun, a corrupt member, an encrypted one, a compression method this
+    Python cannot decode) so a bad upload is a rejected archive and not a 500.
     """
+    written = 0
     try:
-        with zf.open(info) as fh:
-            data = fh.read(budget + 1)
-    except zipfile.BadZipFile as exc:
-        raise ValueError(f"archive member {info.filename} is corrupt: {exc}") from exc
-    if len(data) > budget:
-        raise ValueError(f"archive member {info.filename} exceeds the size limit")
-    return data
+        with zf.open(info) as src, dest.open("wb") as out:
+            while True:
+                chunk = src.read(min(_STREAM_CHUNK, budget - written + 1))
+                if not chunk:
+                    break
+                written += len(chunk)
+                if written > budget:
+                    # ValueError, deliberately: it passes through the except
+                    # clause below untouched and reaches the caller as is.
+                    raise ValueError(
+                        f"archive member {info.filename} exceeds the size limit"
+                    )
+                out.write(chunk)
+    except (zipfile.BadZipFile, RuntimeError, NotImplementedError, EOFError) as exc:
+        # RuntimeError is what zipfile raises for an encrypted member and
+        # NotImplementedError for a compression method it cannot decode;
+        # neither is a bug in the broker.
+        raise ValueError(f"archive member {info.filename} is unreadable: {exc}") from exc
+    return written
 
 
 def _build_save_archive(baseline: float) -> bytes | None:
@@ -957,7 +1025,16 @@ def _build_save_archive(baseline: float) -> bytes | None:
 
     Returns None when there is nothing to sync: no data dir yet, or no file
     changed since `baseline`. Member paths are relative to the data dir so a
-    later PUT restores them regardless of which candidate dir is live."""
+    later PUT restores them regardless of which candidate dir is live.
+
+    Holds the save tree lock: a GET landing during a restore's rename loop used
+    to zip a tree that was half old and half new and ship that mixture to RomM
+    as if it were one coherent snapshot."""
+    with _save_file_lock:
+        return _build_save_archive_locked(baseline)
+
+
+def _build_save_archive_locked(baseline: float) -> bytes | None:
     root = _save_data_root()
     if root is None:
         log.debug("save-file: no Dolphin data dir found")
@@ -1004,15 +1081,26 @@ def _mkdirs_owned(path: Path) -> None:
 
 
 def _extract_save_archive(source: bytes | Path) -> tuple[int, int] | str:
+    """Restore a pulled save archive, one restore at a time."""
+    with _save_file_lock:
+        return _extract_save_archive_locked(source)
+
+
+def _extract_save_archive_locked(source: bytes | Path) -> tuple[int, int] | str:
     """Restore a pulled save archive into the data dir.
 
     Returns (written, skipped) on success, or an error string for a bad
     archive. Existing files newer than their archive member are skipped so a
     restore can never roll back saves made since the archive was taken.
 
-    Every member is written to a temp file first and only renamed into place
-    once all of them are on disk: a failure partway through used to leave the
-    save tree half restored, with no record of which half."""
+    Every member is written into a staging dir first and only renamed into
+    place once all of them are on disk: a failure partway through used to leave
+    the save tree half restored, with no record of which half.
+
+    The staging dir sits beside the save subtrees, not inside them. Staging in
+    the live tree meant a crash mid-restore left dotfile temps among the user's
+    saves, where the next GET /save-file happily zipped them up and shipped
+    them to RomM."""
     root = _save_data_root() or _SAVE_DATA_ROOTS[0]
     try:
         zf = _open_archive(source)
@@ -1032,10 +1120,23 @@ def _extract_save_archive(source: bytes | Path) -> tuple[int, int] | str:
             ):
                 return f"archive member outside save subtrees: {info.filename}"
 
+        staging = root / RESTORE_STAGING_DIR
+        shutil.rmtree(staging, ignore_errors=True)
         staged: list[tuple[Path, Path, float]] = []
         skipped = 0
+        # Its own try: a staging dir that cannot be made is not a member
+        # failure, and reporting it as one named a file the archive never had.
         try:
-            for info in infos:
+            _mkdirs_owned(staging)
+        except OSError as exc:
+            return f"could not create the staging dir {staging.name}: {exc}"
+
+        failed = None
+        try:
+            for index, info in enumerate(infos):
+                # Set before the skip check, not after: a stat that fails on
+                # the target still has to name the member it was checking.
+                failed = info.filename
                 target = root / PurePosixPath(info.filename)
                 mtime = time.mktime(info.date_time + (0, 0, -1))
                 if (
@@ -1044,20 +1145,16 @@ def _extract_save_archive(source: bytes | Path) -> tuple[int, int] | str:
                 ):
                     skipped += 1
                     continue
-                data = _read_member(zf, info, budget)
-                budget -= len(data)
-                _mkdirs_owned(target.parent)
-                tmp = target.parent / f".{target.name}.tmp"
-                tmp.write_bytes(data)
+                # Flat, index-named: member paths are arbitrarily nested and
+                # only the rename below decides where a file ends up.
+                tmp = staging / f"{index:06d}"
+                budget -= _extract_member(zf, info, tmp, budget)
                 os.chown(tmp, _LOG_UID, _LOG_GID)
+                _mkdirs_owned(target.parent)
                 staged.append((tmp, target, mtime))
         except (OSError, ValueError) as exc:
-            for tmp, _target, _mtime in staged:
-                try:
-                    tmp.unlink()
-                except OSError:
-                    pass
-            return f"could not write {info.filename}: {exc}"
+            shutil.rmtree(staging, ignore_errors=True)
+            return f"could not restore {failed}: {exc}"
 
         for tmp, target, mtime in staged:
             try:
@@ -1067,7 +1164,9 @@ def _extract_save_archive(source: bytes | Path) -> tuple[int, int] | str:
                 # Past the point of no return: some files are already live.
                 # Report it rather than pretending the restore was clean.
                 log.error("save-file: could not commit %s: %s", target, exc)
+                shutil.rmtree(staging, ignore_errors=True)
                 return f"could not write {target.name}: {exc}"
+        shutil.rmtree(staging, ignore_errors=True)
     return (len(staged), skipped)
 
 
@@ -1256,14 +1355,13 @@ def _replace_memory_card_locked(source: bytes | Path) -> tuple[int] | str:
             _mkdirs_owned(staging)
             written = 0
             for info in infos:
+                # Written straight to its final name: the whole staging dir is
+                # discarded on failure, so a half-written member inside it can
+                # never be mistaken for part of the live card.
                 target = staging / PurePosixPath(info.filename)
-                data = _read_member(zf, info, budget)
-                budget -= len(data)
                 _mkdirs_owned(target.parent)
-                tmp = target.parent / f".{target.name}.tmp"
-                tmp.write_bytes(data)
-                os.chown(tmp, _LOG_UID, _LOG_GID)
-                os.replace(tmp, target)
+                budget -= _extract_member(zf, info, target, budget)
+                os.chown(target, _LOG_UID, _LOG_GID)
                 written += 1
             # Swap staging over the live card: move the old card aside, move the
             # new one into place, then drop the old. Both live under the same
@@ -1359,7 +1457,7 @@ class BrokerHandler(BaseHTTPRequestHandler):
             self._send_json(413, {"error": "archive too large"})
             return None
 
-        fd, name = tempfile.mkstemp(prefix=".broker-upload-")
+        fd, name = tempfile.mkstemp(prefix=".broker-upload-", dir=_spool_dir())
         path = Path(name)
         remaining = length
         try:
@@ -1427,13 +1525,20 @@ class BrokerHandler(BaseHTTPRequestHandler):
         self.send_header("X-State-Filename", state_path.name)
         self.end_headers()
         sent = 0
-        with fh:
-            while sent < size:
-                chunk = fh.read(min(_STREAM_CHUNK, size - sent))
-                if not chunk:
-                    break
-                self.wfile.write(chunk)
-                sent += len(chunk)
+        try:
+            with fh:
+                while sent < size:
+                    chunk = fh.read(min(_STREAM_CHUNK, size - sent))
+                    if not chunk:
+                        break
+                    self.wfile.write(chunk)
+                    sent += len(chunk)
+        except (BrokenPipeError, ConnectionResetError):
+            # RomM hung up mid-pull. Nothing to report to a socket that is
+            # already gone, and it is not an error worth a traceback.
+            log.info("state-file: client disconnected after %d of %d bytes", sent, size)
+            self.close_connection = True
+            return
         if sent != size:
             # The body is already short; the connection is the only signal left.
             log.error("state-file: %s shrank mid-send (%d of %d bytes)", state_path.name, sent, size)
@@ -1960,6 +2065,7 @@ def main():
     # and a card left stranded by an interrupted swap should be back in place
     # before Dolphin is ever pointed at it.
     _recover_memory_card()
+    _clear_spool()
 
     _patch_ini()
 

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -32,11 +32,6 @@ if not (1 <= SAVE_SLOT <= 7):
 # Returns as soon as the file size is stable, so raising this only affects the
 # failure path. Falls back to a fixed 3 s sleep if the StateSaves dir is absent.
 SSTATE_WAIT   = float(os.environ.get("SSTATE_WAIT", "10.0"))
-# Resume-from-state (launch with load_slot): how long to wait for the game
-# window to appear, and how long to let the game settle before the deferred
-# slot load. Dolphin has no IPC status probe, so the settle is generous.
-RESUME_LOAD_WAIT   = float(os.environ.get("RESUME_LOAD_WAIT",   "90.0"))
-RESUME_LOAD_SETTLE = float(os.environ.get("RESUME_LOAD_SETTLE", "8.0"))
 
 # Dolphin writes savestates to StateSaves under its data dir; the location
 # varies by build (XDG vs. non-XDG layout), so both are probed at save time.
@@ -320,7 +315,7 @@ def _wait_dolphin_gone(timeout: float = 5.0) -> None:
     log.warning("dolphin-emu still running after %.1fs — continuing anyway", timeout)
 
 
-def _launch_dolphin_internal(rom_path):
+def _launch_dolphin_internal(rom_path, state_path=None):
     """Launch dolphin-emu as abc via sudo+env."""
     cmd = [
         "sudo", "-u", "abc", "env",
@@ -337,6 +332,15 @@ def _launch_dolphin_internal(rom_path):
         # --batch, when emulation stops Dolphin returns to its main menu rather
         # than exiting — this is the desired idle behaviour.
         cmd.append(f"--exec={rom_path}")
+
+        # Resume-from-state is done at boot, not by a deferred hotkey. Dolphin
+        # threads --save_state through BootSessionData and applies it as part
+        # of the boot itself, so the game never runs un-resumed: no window
+        # poll, no settle delay, and no window in which the player sees the
+        # title screen before the state snaps in. Only set alongside --exec;
+        # Dolphin rejects a save state with no game to launch.
+        if state_path:
+            cmd.append(f"--save_state={state_path}")
 
     log.info("Launching Dolphin (rom=%s)", rom_path or "dashboard")
     log.debug("Launching: %s", " ".join(cmd))
@@ -442,15 +446,15 @@ def _cleanup_stale_sockets():
         )
 
 
-def _launch_dolphin(rom_path):
+def _launch_dolphin(rom_path, state_path=None):
     try:
-        _launch_dolphin_inner(rom_path)
+        _launch_dolphin_inner(rom_path, state_path)
     finally:
         with _session_lock:
             _session["launch_in_progress"] = False
 
 
-def _launch_dolphin_inner(rom_path):
+def _launch_dolphin_inner(rom_path, state_path=None):
     # Auto-save before killing the current game (covers both navigate-away and
     # game-switching).  Skipped when no game is running, when the emulator
     # already died (crash-relaunch path — a keystroke to a dead process would
@@ -497,7 +501,7 @@ def _launch_dolphin_inner(rom_path):
         # save pull still sees the files the last game wrote.
         if rom_path:
             _session["save_baseline"] = time.time()
-    _launch_dolphin_internal(rom_path)
+    _launch_dolphin_internal(rom_path, state_path)
 
 
 # ── xdotool helpers ───────────────────────────────────────────────────────────
@@ -710,27 +714,6 @@ def _xdotool_load_state(slot: int) -> bool:
         return False
     log.info("xdotool: F%d sent to window %s", slot, wid)
     return True
-
-
-def _deferred_load_state(slot: int) -> None:
-    """Resume-from-state: send the load key once the launched game is up.
-
-    Waits for launch_in_progress to clear first — the old instance is dead and
-    gone by then, so any window found afterwards belongs to the new game. The
-    settle delay lets the game boot far enough to accept the hotkey.
-    """
-    deadline = time.monotonic() + RESUME_LOAD_WAIT
-    while time.monotonic() < deadline:
-        with _session_lock:
-            launching = _session["launch_in_progress"]
-            running = _session["rom_path"] is not None
-        if not launching and running and _xdotool_find_window() is not None:
-            time.sleep(RESUME_LOAD_SETTLE)
-            ok = _xdotool_load_state(slot)
-            log.info("resume: deferred load of slot %d %s", slot, "delivered" if ok else "failed")
-            return
-        time.sleep(1.0)
-    log.warning("resume: game window never appeared — slot %d not loaded", slot)
 
 
 def _save_and_exit(slot: int) -> bool:
@@ -1563,7 +1546,7 @@ class BrokerHandler(BaseHTTPRequestHandler):
             self._send_json(422, {"error": "rom_path does not exist", "path": str(rom_path)})
             return
 
-        # Resume-from-state: load this slot once the game window is up.
+        # Resume-from-state: hand the state to Dolphin at boot.
         load_slot = body.get("load_slot")
         if load_slot is not None and (
             not isinstance(load_slot, int) or not (1 <= load_slot <= 8)
@@ -1571,14 +1554,32 @@ class BrokerHandler(BaseHTTPRequestHandler):
             self._send_json(400, {"error": "load_slot must be 1–8"})
             return
 
+        # Same slot-to-file resolution GET /state-file uses. A resume is always
+        # preceded by RomM PUTting the state, so the newest file for the slot is
+        # the one just written. Resolved here rather than in the launch thread
+        # so a missing state is reported to the caller instead of silently
+        # booting an un-resumed game.
+        state_path = None
+        if load_slot is not None:
+            state_path = _newest_state_for_slot(load_slot)
+            if state_path is None:
+                self._send_json(404, {
+                    "error": "no state file for slot", "slot": load_slot,
+                })
+                return
+
         with _session_lock:
             _session["launch_in_progress"] = True
-        Thread(target=_launch_dolphin, args=(str(rom_path),), daemon=True).start()
-        if load_slot is not None:
-            Thread(
-                target=_deferred_load_state, args=(load_slot,), daemon=True
-            ).start()
-        self._send_json(200, {"status": "launching", "rom_path": str(rom_path)})
+        Thread(
+            target=_launch_dolphin,
+            args=(str(rom_path), str(state_path) if state_path else None),
+            daemon=True,
+        ).start()
+        self._send_json(200, {
+            "status": "launching",
+            "rom_path": str(rom_path),
+            "load_slot": load_slot,
+        })
 
     def do_DELETE(self):
         if not self._check_secret():

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -14,6 +14,7 @@ import time
 from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
 from pathlib import Path
 from threading import Thread, Lock
+from urllib.parse import parse_qs, urlparse
 
 # ── Config ────────────────────────────────────────────────────────────────────
 
@@ -563,6 +564,41 @@ def _wait_for_sstate_write(state_dir: Path, before: dict, deadline: float) -> bo
     return False
 
 
+# ── State file transfer ───────────────────────────────────────────────────────
+# RomM's backend syncs save states through these helpers: after a save it
+# GETs the freshly written slot file, and on session claim it PUTs the user's
+# stored states back into StateSaves. GET blocks while a save is in flight so
+# the response always carries the completed write.
+
+STATE_FILE_MAX_BYTES = 256 * 1024 * 1024
+STATE_GET_WAIT = float(os.environ.get("STATE_GET_WAIT", "30.0"))
+
+
+def _wait_for_save_idle(deadline: float) -> None:
+    """Block until no save is in flight, or the deadline passes."""
+    while time.monotonic() < deadline:
+        with _session_lock:
+            if not _session["save_in_progress"]:
+                return
+        time.sleep(0.2)
+
+
+def _newest_state_for_slot(slot: int) -> Path | None:
+    """Newest state file for the slot. Dolphin names states `<GameID>.s{slot:02d}`."""
+    state_dir = _sstate_dir()
+    if state_dir is None or not state_dir.is_dir():
+        return None
+    candidates: list[tuple[float, Path]] = []
+    for p in state_dir.glob(f"*.s{slot:02d}"):
+        try:
+            candidates.append((p.stat().st_mtime, p))
+        except OSError:
+            pass
+    if not candidates:
+        return None
+    return max(candidates)[1]
+
+
 def _xdotool_save_state(slot: int) -> bool:
     """Save emulator state to slot (1–8) via Shift+F{slot}.
 
@@ -693,6 +729,100 @@ class BrokerHandler(BaseHTTPRequestHandler):
         except json.JSONDecodeError:
             return {}
 
+    def _get_state_file(self):
+        query = parse_qs(urlparse(self.path).query)
+        try:
+            slot = int(query.get("slot", ["0"])[0])
+        except ValueError:
+            self._send_json(400, {"error": "slot must be an integer"})
+            return
+        if slot == 0:
+            slot = SAVE_SLOT
+        if not (1 <= slot <= 8):
+            self._send_json(400, {"error": "slot must be 0–8"})
+            return
+
+        # Block while a save is being written so the caller never receives a
+        # half-written or stale file right after triggering a save.
+        _wait_for_save_idle(time.monotonic() + STATE_GET_WAIT)
+
+        state_path = _newest_state_for_slot(slot)
+        if state_path is None:
+            self._send_json(404, {"error": "no state file for slot", "slot": slot})
+            return
+        try:
+            content = state_path.read_bytes()
+        except OSError as exc:
+            self._send_json(500, {"error": f"could not read state file: {exc}"})
+            return
+        if len(content) > STATE_FILE_MAX_BYTES:
+            self._send_json(413, {"error": "state file exceeds size limit"})
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(len(content)))
+        self.send_header("X-State-Filename", state_path.name)
+        self.end_headers()
+        self.wfile.write(content)
+        log.info("state-file: served %s (%d bytes)", state_path.name, len(content))
+
+    def do_PUT(self):
+        if not self._check_secret():
+            self._send_json(403, {"error": "forbidden"})
+            return
+        parsed = urlparse(self.path)
+        if parsed.path != "/state-file":
+            self._send_json(404, {"error": "not found"})
+            return
+
+        # Basename only — the filename came from a previous GET and is written
+        # back verbatim so Dolphin recognises the slot; path parts are rejected.
+        raw_name = parse_qs(parsed.query).get("filename", [""])[0]
+        filename = Path(raw_name).name
+        stem, _, ext = filename.rpartition(".")
+        if (
+            not stem
+            or stem.startswith(".")
+            or len(ext) != 3
+            or ext[0] != "s"
+            or not ext[1:].isdigit()
+        ):
+            self._send_json(400, {"error": "filename must be a <GameID>.sNN basename"})
+            return
+
+        try:
+            length = int(self.headers.get("Content-Length", 0))
+        except ValueError:
+            length = 0
+        if length <= 0:
+            self._send_json(400, {"error": "missing or invalid Content-Length"})
+            return
+        if length > STATE_FILE_MAX_BYTES:
+            self._send_json(413, {"error": "state file exceeds size limit"})
+            return
+        content = self.rfile.read(length)
+        if len(content) != length:
+            self._send_json(400, {"error": "truncated request body"})
+            return
+
+        state_dir = _sstate_dir() or _SSTATE_DIR_CANDIDATES[0]
+        tmp = state_dir / f".{filename}.tmp"
+        try:
+            state_dir.mkdir(parents=True, exist_ok=True)
+            tmp.write_bytes(content)
+            # Dolphin runs as abc and must be able to overwrite the slot later.
+            os.chown(tmp, _LOG_UID, _LOG_GID)
+            os.replace(tmp, state_dir / filename)
+        except OSError as exc:
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+            self._send_json(500, {"error": f"could not write state file: {exc}"})
+            return
+        log.info("state-file: stored %s (%d bytes)", filename, length)
+        self._send_json(200, {"status": "ok", "filename": filename})
+
     def do_GET(self):
         if self.path == "/health":
             self._send_json(200, {"status": "ok"})
@@ -700,6 +830,8 @@ class BrokerHandler(BaseHTTPRequestHandler):
             # /health stays open for container healthchecks; all other GETs
             # require the shared secret, matching POST/DELETE.
             self._send_json(403, {"error": "forbidden"})
+        elif urlparse(self.path).path == "/state-file":
+            self._get_state_file()
         elif self.path == "/status":
             with _session_lock:
                 active = (

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -637,6 +637,8 @@ def _xdotool_save_state(slot: int) -> bool:
     if wid is None:
         return False
 
+    _capture_state_screenshot(wid, slot)
+
     state_dir = _sstate_dir()
     before = _sstate_snapshot(state_dir) if state_dir else {}
 
@@ -883,6 +885,81 @@ def _extract_save_archive(content: bytes) -> tuple[int, int] | str:
     return (written, skipped)
 
 
+# ── State screenshots ─────────────────────────────────────────────────────────
+# Dolphin savestates carry no embedded frame (unlike PCSX2's .p2s archives), so
+# the broker takes one itself: the screenshot hotkey fires just before the save
+# key and the PNG Dolphin drops in ScreenShots is filed under the slot, where
+# RomM picks it up as the state's thumbnail. Firing first keeps the "Saved State
+# to Slot N" banner out of the captured frame.
+#
+# Best effort throughout: a state without a thumbnail is fine, so no failure
+# here is allowed to fail the save.
+
+SCREENSHOT_WAIT = float(os.environ.get("SCREENSHOT_WAIT", "5.0"))
+SCREENSHOT_MAX_BYTES = 16 * 1024 * 1024
+
+
+def _screenshot_dir() -> Path:
+    return (_save_data_root() or _SAVE_DATA_ROOTS[0]) / "ScreenShots"
+
+
+def _state_shot_path(slot: int) -> Path:
+    root = _save_data_root() or _SAVE_DATA_ROOTS[0]
+    return root / "romm" / "state-shots" / f"slot{slot:02d}.png"
+
+
+def _screenshot_snapshot(root: Path) -> set:
+    """Every PNG currently under the ScreenShots tree, one game dir per title."""
+    if not root.is_dir():
+        return set()
+    return {p for p in root.rglob("*.png") if p.is_file()}
+
+
+def _capture_state_screenshot(wid: str, slot: int) -> bool:
+    """Fire the screenshot hotkey and move the resulting PNG under the slot."""
+    root = _screenshot_dir()
+    before = _screenshot_snapshot(root)
+    if not _xdotool_key(wid, "F9"):
+        return False
+
+    shot = None
+    deadline = time.monotonic() + SCREENSHOT_WAIT
+    while time.monotonic() < deadline:
+        time.sleep(0.2)
+        new = _screenshot_snapshot(root) - before
+        if new:
+            # Take the newest, in case the user fired their own F9 alongside.
+            shot = max(new, key=lambda p: p.stat().st_mtime)
+            break
+    if shot is None:
+        log.warning("screenshot: no PNG appeared within %.1fs", SCREENSHOT_WAIT)
+        return False
+
+    # The hotkey returns before the encode finishes, so wait for a stable size.
+    last = -1
+    while time.monotonic() < deadline:
+        try:
+            size = shot.stat().st_size
+        except OSError:
+            return False
+        if size > 0 and size == last:
+            break
+        last = size
+        time.sleep(0.2)
+
+    target = _state_shot_path(slot)
+    try:
+        _mkdirs_owned(target.parent)
+        # Dolphin wrote it, so this is a move within /config: the screenshot was
+        # taken for the state and is not one the player asked to keep.
+        os.replace(shot, target)
+    except OSError as exc:
+        log.warning("screenshot: could not file %s under slot %d: %s", shot, slot, exc)
+        return False
+    log.info("screenshot: slot %d thumbnail captured (%d bytes)", slot, last)
+    return True
+
+
 # ── HTTP handler ──────────────────────────────────────────────────────────────
 
 class BrokerHandler(BaseHTTPRequestHandler):
@@ -954,6 +1031,39 @@ class BrokerHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(content)
         log.info("state-file: served %s (%d bytes)", state_path.name, len(content))
+
+    def _get_state_screenshot(self):
+        query = parse_qs(urlparse(self.path).query)
+        try:
+            slot = int(query.get("slot", ["0"])[0])
+        except ValueError:
+            self._send_json(400, {"error": "slot must be an integer"})
+            return
+        if slot == 0:
+            slot = SAVE_SLOT
+        if not (1 <= slot <= AUTOSAVE_SLOT):
+            self._send_json(400, {"error": f"slot must be 0–{AUTOSAVE_SLOT}"})
+            return
+
+        # A save in flight is about to overwrite this slot's thumbnail; wait it
+        # out so the caller never pairs a new state with the previous frame.
+        _wait_for_save_idle(time.monotonic() + STATE_GET_WAIT)
+
+        path = _state_shot_path(slot)
+        try:
+            content = path.read_bytes()
+        except OSError:
+            self._send_json(404, {"error": "no screenshot for slot", "slot": slot})
+            return
+        if not content or len(content) > SCREENSHOT_MAX_BYTES:
+            self._send_json(413, {"error": "screenshot exceeds size limit"})
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "image/png")
+        self.send_header("Content-Length", str(len(content)))
+        self.end_headers()
+        self.wfile.write(content)
+        log.info("state-screenshot: served slot %d (%d bytes)", slot, len(content))
 
     def _get_save_file(self):
         with _session_lock:
@@ -1069,6 +1179,8 @@ class BrokerHandler(BaseHTTPRequestHandler):
             self._get_state_file()
         elif urlparse(self.path).path == "/save-file":
             self._get_save_file()
+        elif urlparse(self.path).path == "/state-screenshot":
+            self._get_state_screenshot()
         elif self.path == "/status":
             with _session_lock:
                 active = (

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -248,6 +248,17 @@ def _kill_dolphin():
         pass  # already gone
 
 
+def _wait_dolphin_gone(timeout: float = 5.0) -> None:
+    """Poll until no dolphin-emu process remains, so the new instance doesn't
+    race the old one for the X display and gamepad sockets."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if subprocess.run(["pgrep", "-x", "dolphin-emu"], capture_output=True).returncode != 0:
+            return
+        time.sleep(0.2)
+    log.warning("dolphin-emu still running after %.1fs — continuing anyway", timeout)
+
+
 def _launch_dolphin_internal(rom_path):
     """Launch dolphin-emu as abc via sudo+env."""
     cmd = [
@@ -372,13 +383,19 @@ def _cleanup_stale_sockets():
 
 def _launch_dolphin(rom_path):
     # Auto-save before killing the current game (covers both navigate-away and
-    # game-switching).  Skipped when no game is running or a save is already in
-    # progress (e.g. called from /save-and-exit which saves first then kills).
-    # Read and set save_in_progress atomically to avoid a TOCTOU race with a
-    # concurrent /save-and-exit request.
+    # game-switching).  Skipped when no game is running, when the emulator
+    # already died (crash-relaunch path — a keystroke to a dead process would
+    # just poll for a savestate write that never comes), or when a save is
+    # already in progress (e.g. called from /save-and-exit which saves first
+    # then kills).  Read and set save_in_progress atomically to avoid a TOCTOU
+    # race with a concurrent /save-and-exit request.
     with _session_lock:
         old_game = _session["rom_path"]
-        if old_game is not None and not _session["save_in_progress"]:
+        emulator_alive = (
+            _session["process"] is not None
+            and _session["process"].poll() is None
+        )
+        if old_game is not None and emulator_alive and not _session["save_in_progress"]:
             _session["save_in_progress"] = True
             do_autosave = True
         else:
@@ -398,11 +415,15 @@ def _launch_dolphin(rom_path):
 
     _kill_dolphin()
     _patch_ini(fullscreen=bool(rom_path))
-    time.sleep(2)
+    _wait_dolphin_gone()
     with _session_lock:
         _session["rom_path"] = rom_path
         _session["rom_name"] = Path(rom_path).stem if rom_path else "Dashboard"
-        _session["started_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        # started_at marks when a *game* session began; the idle dashboard has
+        # no session start.
+        _session["started_at"] = (
+            time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()) if rom_path else None
+        )
     _launch_dolphin_internal(rom_path)
 
 
@@ -653,7 +674,6 @@ class BrokerHandler(BaseHTTPRequestHandler):
         self.send_response(code)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(payload)))
-        self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
         self.wfile.write(payload)
 
@@ -672,6 +692,10 @@ class BrokerHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         if self.path == "/health":
             self._send_json(200, {"status": "ok"})
+        elif not self._check_secret():
+            # /health stays open for container healthchecks; all other GETs
+            # require the shared secret, matching POST/DELETE.
+            self._send_json(403, {"error": "forbidden"})
         elif self.path == "/status":
             with _session_lock:
                 active = (
@@ -857,13 +881,6 @@ class BrokerHandler(BaseHTTPRequestHandler):
         log.info("Soft reset: returning to dashboard")
         self._send_json(200, {"status": "resetting"})
 
-    def do_OPTIONS(self):
-        self.send_response(204)
-        self.send_header("Access-Control-Allow-Origin", "*")
-        self.send_header("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
-        self.send_header("Access-Control-Allow-Headers", "Content-Type, X-Broker-Secret")
-        self.end_headers()
-
 
 # ── Main ──────────────────────────────────────────────────────────────────────
 
@@ -895,10 +912,12 @@ def main():
     time.sleep(5)
 
     # Kill any stale Dolphin instance left from a previous broker run.
-    result = subprocess.run(["pkill", "-9", "-f", "/usr/games/dolphin-emu"], capture_output=True)
+    # -x matches the process name exactly; -f with a path substring would also
+    # match unrelated processes whose command line mentions the binary.
+    result = subprocess.run(["pkill", "-9", "-x", "dolphin-emu"], capture_output=True)
     if result.returncode == 0:
         log.info("Killed stale dolphin-emu instance(s) on startup.")
-        time.sleep(2)
+        _wait_dolphin_gone()
 
     _patch_ini()
 

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -11,7 +11,7 @@ import socket as _socket
 import subprocess
 import sys
 import time
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
 from pathlib import Path
 from threading import Thread, Lock
 
@@ -24,7 +24,17 @@ SAVE_SLOT     = int(os.environ.get("SAVE_SLOT", "1"))  # default slot for manual
 AUTOSAVE_SLOT = 8                                       # slot 8 is reserved exclusively for auto-saves
 if not (1 <= SAVE_SLOT <= 7):
     raise SystemExit(f"SAVE_SLOT must be 1–7, got {SAVE_SLOT}")
-SSTATE_WAIT   = float(os.environ.get("SSTATE_WAIT", "3.0"))  # seconds to wait after save key
+# Max seconds to poll for the savestate write to complete after the save key.
+# Returns as soon as the file size is stable, so raising this only affects the
+# failure path. Falls back to a fixed 3 s sleep if the StateSaves dir is absent.
+SSTATE_WAIT   = float(os.environ.get("SSTATE_WAIT", "10.0"))
+
+# Dolphin writes savestates to StateSaves under its data dir; the location
+# varies by build (XDG vs. non-XDG layout), so both are probed at save time.
+_SSTATE_DIR_CANDIDATES = (
+    Path("/config/.local/share/dolphin-emu/StateSaves"),
+    Path("/config/.config/dolphin-emu/StateSaves"),
+)
 
 ENV = {
     "DISPLAY":            ":0",
@@ -48,6 +58,13 @@ ENV = {
 # Dolphin on this image writes all config files directly to
 # ~/.config/dolphin-emu/ — there is no Config/ subdirectory.
 INI_PATH = Path("/config/.config/dolphin-emu/Dolphin.ini")
+
+# Dolphin's stdout/stderr is redirected at fd level to this file. A Python
+# reader thread on a PIPE is not used: if the reader dies, Dolphin blocks
+# forever once the 64 KB pipe buffer fills.
+DOLPHIN_LOG_PATH = Path(os.environ.get("DOLPHIN_LOG_PATH", "/config/dolphin.log"))
+_LOG_UID = int(os.environ.get("PUID", "1000"))
+_LOG_GID = int(os.environ.get("PGID", "1000"))
 
 logging.basicConfig(
     level=getattr(logging, os.environ.get("BROKER_LOG_LEVEL", "INFO").upper(), logging.INFO),
@@ -88,34 +105,44 @@ def _patch_ini(fullscreen: bool = False):
     fullscreen=True when launching a game (fills stream with game content),
     False for the idle dashboard (windowed, avoids black screen on boot).
     """
-    INI_PATH.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        INI_PATH.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        log.error("Could not create %s: %s — skipping ini patch",
+                  INI_PATH.parent, exc)
+        return
 
     fs_val = "True" if fullscreen else "False"
 
     if not INI_PATH.exists():
-        INI_PATH.write_text(
-            "[General]\n"
-            "BackgroundInput = True\n"
-            "\n"
-            "[Core]\n"
-            "SIDevice0 = 6\n"
-            "SIDevice1 = 0\n"
-            "SIDevice2 = 0\n"
-            "SIDevice3 = 0\n"
-            "GFXBackend = OpenGL\n"
-            "CPUThread = False\n"
-            "\n"
-            "[Interface]\n"
-            "ConfirmStop = False\n"
-            "\n"
-            "[Display]\n"
-            "RenderToMain = False\n"
-            f"Fullscreen = {fs_val}\n"
-            "\n"
-            "[Analytics]\n"
-            "Enabled = False\n"
-            "PermissionAsked = True\n"
-        )
+        try:
+            INI_PATH.write_text(
+                "[General]\n"
+                "BackgroundInput = True\n"
+                "\n"
+                "[Core]\n"
+                "SIDevice0 = 6\n"
+                "SIDevice1 = 0\n"
+                "SIDevice2 = 0\n"
+                "SIDevice3 = 0\n"
+                "GFXBackend = OpenGL\n"
+                "CPUThread = False\n"
+                "\n"
+                "[Interface]\n"
+                "ConfirmStop = False\n"
+                "\n"
+                "[Display]\n"
+                "RenderToMain = False\n"
+                f"Fullscreen = {fs_val}\n"
+                "\n"
+                "[Analytics]\n"
+                "Enabled = False\n"
+                "PermissionAsked = True\n"
+            )
+        except OSError as exc:
+            log.error("Could not create %s: %s — broker defaults not applied",
+                      INI_PATH, exc)
+            return
         log.info("Created Dolphin.ini with broker defaults (fullscreen=%s)", fullscreen)
         return
 
@@ -163,14 +190,25 @@ def _patch_ini(fullscreen: bool = False):
             else:
                 new_lines.append(line)
 
-        # Append any keys that weren't found in the file.
+        # Insert missing keys under their existing section header; only create
+        # the section if the file doesn't have it at all. Blindly appending a
+        # second [section] block at EOF accumulates duplicate headers.
         for section, keys in target.items():
             missing = {k: v for k, v in keys.items() if k not in applied[section]}
-            if missing:
+            if not missing:
+                continue
+            header_idx = next(
+                (i for i, l in enumerate(new_lines) if l.strip() == f"[{section}]"),
+                None,
+            )
+            add_lines = [f"{k} = {v}" for k, v in missing.items()]
+            if header_idx is None:
                 new_lines.append(f"[{section}]")
-                for k, v in missing.items():
-                    new_lines.append(f"{k} = {v}")
-                    log.warning("Dolphin.ini: [%s] %s not found — appended", section, k)
+                new_lines.extend(add_lines)
+            else:
+                new_lines[header_idx + 1:header_idx + 1] = add_lines
+            for k in missing:
+                log.warning("Dolphin.ini: [%s] %s not found — inserted", section, k)
 
         tmp = INI_PATH.with_suffix(".tmp")
         tmp.write_text("\n".join(new_lines) + "\n")
@@ -202,7 +240,10 @@ def _kill_dolphin():
         except subprocess.TimeoutExpired:
             log.warning("Dolphin did not exit after SIGTERM — sending SIGKILL")
             os.killpg(pgid, signal.SIGKILL)
-            proc.wait()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                log.error("Dolphin did not exit after SIGKILL — giving up")
     except ProcessLookupError:
         pass  # already gone
 
@@ -228,62 +269,45 @@ def _launch_dolphin_internal(rom_path):
     log.info("Launching Dolphin (rom=%s)", rom_path or "dashboard")
     log.debug("Launching: %s", " ".join(cmd))
 
+    # Append mode keeps history across launches. Failure to open is non-fatal:
+    # Dolphin still launches, just without captured output.
+    log_fh = None
+    try:
+        log_fh = open(DOLPHIN_LOG_PATH, "ab", buffering=0)
+        try:
+            os.chown(DOLPHIN_LOG_PATH, _LOG_UID, _LOG_GID)
+        except (OSError, PermissionError):
+            pass
+        log_fh.write(f"\n=== {time.strftime('%Y-%m-%d %H:%M:%S')} launch (rom={rom_path or 'dashboard'}) ===\n".encode())
+        log_fh.flush()
+    except OSError as exc:
+        log.warning("Cannot open %s for Dolphin output capture (%s); continuing without capture.", DOLPHIN_LOG_PATH, exc)
+
     try:
         proc = subprocess.Popen(
             cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
+            stdout=log_fh if log_fh else subprocess.DEVNULL,
+            stderr=subprocess.STDOUT if log_fh else subprocess.DEVNULL,
             preexec_fn=os.setpgrp,
         )
     except Exception as exc:
         log.error("Failed to launch Dolphin: %s", exc)
+        if log_fh:
+            log_fh.close()
         with _session_lock:
             _session["process"] = None
             _session["is_managed"] = False
         return
+    finally:
+        # Popen dup'd the fd; close our handle so it isn't leaked.
+        if log_fh:
+            log_fh.close()
 
     with _session_lock:
         _session["process"] = proc
         _session["is_managed"] = True
     log.info("Dolphin launched (PID %d)", proc.pid)
     Thread(target=_monitor_process, args=(proc, time.monotonic()), daemon=True).start()
-    Thread(target=_log_dolphin_output, args=(proc,), daemon=True).start()
-    Thread(target=_diag_window, args=(proc.pid,), daemon=True).start()
-
-
-def _log_dolphin_output(proc):
-    """Log Dolphin stdout/stderr to the broker log for crash diagnosis."""
-    try:
-        for raw in proc.stdout:
-            line = raw.decode(errors="replace").rstrip()
-            if line:
-                log.info("[dolphin] %s", line)
-    except Exception:
-        pass
-
-
-def _diag_window(pid: int):
-    """After a short delay, check whether Dolphin has an X11 window via xdotool.
-
-    Uses classname search rather than --pid because proc.pid is the sudo wrapper,
-    not the actual dolphin-emu process, so --pid never finds the window.
-    """
-    time.sleep(4)
-    try:
-        out = subprocess.check_output(
-            ["sudo", "-u", "abc", "env",
-             f"DISPLAY={ENV['DISPLAY']}", f"HOME={ENV['HOME']}",
-             "xdotool", "search", "--classname", "dolphin-emu"],
-            text=True, timeout=10,
-        ).strip()
-        if out:
-            log.info("[diag] Dolphin has X11 window(s): %s", out)
-        else:
-            log.warning("[diag] Dolphin has NO X11 windows (sudo PID %d) — check Xwayland/rendering", pid)
-    except subprocess.CalledProcessError:
-        log.warning("[diag] xdotool found no X11 windows for Dolphin (sudo PID %d)", pid)
-    except Exception as exc:
-        log.warning("[diag] xdotool check failed: %s", exc)
 
 
 def _monitor_process(proc, start_time):
@@ -455,20 +479,91 @@ def _xdotool_key(wid: str, key: str) -> bool:
         return False
 
 
+def _sstate_dir() -> Path | None:
+    """Return Dolphin's StateSaves dir, honouring an SSTATE_DIR override."""
+    env = os.environ.get("SSTATE_DIR")
+    if env:
+        return Path(env)
+    for c in _SSTATE_DIR_CANDIDATES:
+        if c.is_dir():
+            return c
+    return None
+
+
+def _sstate_snapshot(state_dir: Path) -> dict:
+    """Return {Path: (size, mtime)} for every file currently in state_dir."""
+    snap = {}
+    try:
+        for p in state_dir.iterdir():
+            try:
+                st = p.stat()
+                snap[p] = (st.st_size, st.st_mtime)
+            except OSError:
+                pass
+    except OSError:
+        pass
+    return snap
+
+
+def _wait_for_sstate_write(state_dir: Path, before: dict, deadline: float) -> bool:
+    """Poll state_dir until a savestate write completes or deadline passes.
+
+    Detects new files and overwrites (mtime change), then waits for the size
+    to be stable for 0.5 s. Killing Dolphin on a fixed timer instead of write
+    confirmation truncates large states mid-flush.
+    """
+    STABLE_SECS = 0.5
+    POLL_SECS   = 0.1
+    target = last_size = stable_since = None
+
+    while time.monotonic() < deadline:
+        after = _sstate_snapshot(state_dir)
+        if target is None:
+            for p, (size, mtime) in after.items():
+                prev = before.get(p)
+                if prev is None or prev[1] != mtime:
+                    target, last_size, stable_since = p, size, time.monotonic()
+                    log.debug("Save: write detected — %s (%d bytes)", p.name, size)
+                    break
+        else:
+            cur = after.get(target)
+            if cur is None:
+                target = None
+            elif cur[0] != last_size:
+                last_size, stable_since = cur[0], time.monotonic()
+            elif time.monotonic() - stable_since >= STABLE_SECS:
+                log.info("Save: state write complete — %s (%d bytes)", target.name, last_size)
+                return True
+        time.sleep(POLL_SECS)
+    return False
+
+
 def _xdotool_save_state(slot: int) -> bool:
     """Save emulator state to slot (1–8) via Shift+F{slot}.
 
     Dolphin maps Shift+F1–Shift+F8 directly to save slots 1–8, so no slot
-    cycling is needed. Sends the key then waits SSTATE_WAIT seconds for the
-    write to complete before returning.
+    cycling is needed. Sends the key then polls StateSaves for the write to
+    complete (up to SSTATE_WAIT seconds) so a follow-up kill cannot land
+    mid-flush. Falls back to a fixed 3 s sleep if StateSaves can't be found.
     """
     wid = _xdotool_find_window()
     if wid is None:
         return False
+
+    state_dir = _sstate_dir()
+    before = _sstate_snapshot(state_dir) if state_dir else {}
+
     if not _xdotool_key(wid, f"shift+F{slot}"):
         return False
-    log.info("xdotool: shift+F%d sent to window %s — waiting %.1fs for write", slot, wid, SSTATE_WAIT)
-    time.sleep(SSTATE_WAIT)
+
+    if state_dir is None:
+        log.warning("Save: StateSaves dir not found — falling back to fixed 3.0s wait")
+        time.sleep(3.0)
+        return True
+
+    log.info("xdotool: shift+F%d sent to window %s — waiting for write (max %.1fs)", slot, wid, SSTATE_WAIT)
+    if not _wait_for_sstate_write(state_dir, before, time.monotonic() + SSTATE_WAIT):
+        log.warning("Save: state write not confirmed within %.1fs (key was sent)", SSTATE_WAIT)
     return True
 
 
@@ -504,11 +599,20 @@ _PACTL_CMD = [
 
 
 def _pactl(*args: str) -> subprocess.CompletedProcess:
-    """Run pactl as abc so it connects to abc's PulseAudio instance."""
-    return subprocess.run(
-        _PACTL_CMD + ["pactl"] + list(args),
-        capture_output=True, text=True, timeout=5,
-    )
+    """Run pactl as abc so it connects to abc's PulseAudio instance.
+
+    A hung or missing pactl is reported as a non-zero CompletedProcess (rather
+    than raising) so the /volume and /mute handlers return a 500 instead of
+    dropping the connection with an unhandled exception."""
+    cmd = _PACTL_CMD + ["pactl"] + list(args)
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=5)
+    except subprocess.TimeoutExpired:
+        log.error("pactl timed out: %s", " ".join(args))
+        return subprocess.CompletedProcess(cmd, 124, "", "pactl timed out")
+    except OSError as exc:
+        log.error("pactl failed to run: %s", exc)
+        return subprocess.CompletedProcess(cmd, 127, "", str(exc))
 
 
 def _pactl_get_mute() -> bool | None:
@@ -555,7 +659,7 @@ class BrokerHandler(BaseHTTPRequestHandler):
 
     def _read_body(self) -> dict:
         try:
-            length = min(int(self.headers.get("Content-Length", 0)), 64 * 1024)
+            length = max(0, min(int(self.headers.get("Content-Length", 0)), 64 * 1024))
         except ValueError:
             length = 0
         if length == 0:
@@ -763,6 +867,27 @@ class BrokerHandler(BaseHTTPRequestHandler):
 
 # ── Main ──────────────────────────────────────────────────────────────────────
 
+def _graceful_shutdown(server: HTTPServer, signum: int) -> None:
+    """Stop the HTTP listener, let any in-flight save finish, then kill Dolphin.
+    Triggered on SIGTERM/SIGINT — serve_forever()'s KeyboardInterrupt path does
+    not cover SIGTERM from s6/systemd, which previously hard-killed Dolphin
+    mid-savestate on container stop."""
+    log.info("Received signal %d — beginning graceful shutdown", signum)
+    Thread(target=server.shutdown, daemon=True).start()
+
+    deadline = time.monotonic() + max(SSTATE_WAIT, 5.0)
+    while time.monotonic() < deadline:
+        with _session_lock:
+            if not _session["save_in_progress"]:
+                break
+        time.sleep(0.2)
+    else:
+        log.warning("Shutdown: in-flight save did not complete within %.1fs — killing Dolphin anyway", SSTATE_WAIT)
+
+    _kill_dolphin()
+    log.info("Shutdown complete")
+
+
 def main():
     log.info("Broker starting — waiting 5s for desktop...")
     if not SECRET:
@@ -786,14 +911,23 @@ def main():
     # whenever no game is playing.  Game launches kill this instance first.
     Thread(target=_launch_dolphin, args=(None,), daemon=True).start()
 
-    server = HTTPServer(("0.0.0.0", PORT), BrokerHandler)
+    # ThreadingHTTPServer: /save-and-exit with wait=true runs xdotool plus the
+    # savestate write poll inline; a single-threaded server would stall /health
+    # and /status for the duration. Session state is lock-protected.
+    server = ThreadingHTTPServer(("0.0.0.0", PORT), BrokerHandler)
     log.info("ROM broker listening on port %d", PORT)
     if SECRET:
         log.info("Shared secret auth enabled")
 
+    def _handle(signum, _frame):
+        _graceful_shutdown(server, signum)
+
+    signal.signal(signal.SIGTERM, _handle)
+    signal.signal(signal.SIGINT, _handle)
+
     try:
         server.serve_forever()
-    except KeyboardInterrupt:
+    finally:
         server.server_close()
 
 

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -608,21 +608,29 @@ def _sstate_snapshot(state_dir: Path) -> dict:
     return snap
 
 
-def _wait_for_sstate_write(state_dir: Path, before: dict, deadline: float) -> bool:
-    """Poll state_dir until a savestate write completes or deadline passes.
+def _wait_for_sstate_write(state_dir: Path, before: dict, deadline: float, slot: int) -> bool:
+    """Poll state_dir until the slot's savestate write completes or deadline passes.
 
     Detects new files and overwrites (mtime change), then waits for the size
     to be stable for 0.5 s. Killing Dolphin on a fixed timer instead of write
     confirmation truncates large states mid-flush.
+
+    Only files named for this slot (`<GameID>.s{slot:02d}`) count. Dolphin
+    writes its undo backup `lastState.sav` first and finishes it well before
+    the slot file, so watching whichever file changes first confirms the save
+    while the state itself is still flushing.
     """
     STABLE_SECS = 0.5
     POLL_SECS   = 0.1
+    suffix = f".s{slot:02d}"
     target = last_size = stable_since = None
 
     while time.monotonic() < deadline:
         after = _sstate_snapshot(state_dir)
         if target is None:
             for p, (size, mtime) in after.items():
+                if not p.name.endswith(suffix):
+                    continue
                 prev = before.get(p)
                 if prev is None or prev[1] != mtime:
                     target, last_size, stable_since = p, size, time.monotonic()
@@ -702,7 +710,7 @@ def _xdotool_save_state(slot: int) -> bool:
         return True
 
     log.info("xdotool: shift+F%d sent to window %s — waiting for write (max %.1fs)", slot, wid, SSTATE_WAIT)
-    if not _wait_for_sstate_write(state_dir, before, time.monotonic() + SSTATE_WAIT):
+    if not _wait_for_sstate_write(state_dir, before, time.monotonic() + SSTATE_WAIT, slot):
         log.warning("Save: state write not confirmed within %.1fs (key was sent)", SSTATE_WAIT)
     return True
 

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -51,8 +51,12 @@ ENV = {
     "HOME":               "/config",
     "USER":               "abc",
     # The joystick interposer hooks open() on /dev/input/* and redirects to
-    # selkies Unix sockets so controller input reaches Dolphin.
-    "LD_PRELOAD": "/usr/lib/selkies_joystick_interposer.so",
+    # selkies Unix sockets so controller input reaches Dolphin. The fake
+    # libudev is required alongside it: /dev/input is empty in the container,
+    # so SDL's udev enumeration finds no devices without it and Dolphin never
+    # opens the interposer's virtual pads.
+    "LD_PRELOAD": os.environ.get("LD_PRELOAD")
+    or "/usr/lib/selkies_joystick_interposer.so:/opt/lib/libudev.so.1.0.0-fake",
 }
 
 # Dolphin on this image writes all config files directly to

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -3,6 +3,7 @@
 
 import glob
 import hmac
+import io
 import json
 import logging
 import os
@@ -11,8 +12,9 @@ import socket as _socket
 import subprocess
 import sys
 import time
+import zipfile
 from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from threading import Thread, Lock
 from urllib.parse import parse_qs, urlparse
 
@@ -97,6 +99,10 @@ _session: dict = {
     # True from POST /launch until _launch_dolphin has swapped instances —
     # gates the deferred resume load so it never fires at the old window.
     "launch_in_progress": False,
+    # Wall-clock stamp of the last GAME launch (not dashboard relaunches).
+    # GET /save-file only ships files modified at or after this point; it
+    # survives game exit so RomM can still pull after the session ends.
+    "save_baseline": None,
 }
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -445,6 +451,10 @@ def _launch_dolphin_inner(rom_path):
         _session["started_at"] = (
             time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()) if rom_path else None
         )
+        # Dashboard relaunches keep the previous baseline so an end-of-session
+        # save pull still sees the files the last game wrote.
+        if rom_path:
+            _session["save_baseline"] = time.time()
     _launch_dolphin_internal(rom_path)
 
 
@@ -731,6 +741,148 @@ def _cleanup_sockets():
         log.warning("Socket cleanup: selkies not found or already stopped.")
 
 
+# ── In-game save sync ─────────────────────────────────────────────────────────
+# Alongside the savestate sync above, RomM syncs Dolphin's own in-game saves:
+# GC memory-card folders (GCI) and Wii NAND title saves. GET /save-file zips
+# every save file modified since the last game launch; PUT /save-file restores
+# a pulled archive before launch. Same guarded, mtime-last-write-wins mechanics
+# as Eden's implementation.
+_SAVE_DATA_ROOTS = (
+    Path("/config/.local/share/dolphin-emu"),
+    Path("/config/.config/dolphin-emu"),
+)
+# Archive members must live under one of these root-relative subtrees; PUT
+# rejects anything else so a crafted zip cannot reach configs, keys or states.
+SAVE_SYNC_SUBTREES = ("GC", "Wii/title")
+SAVE_FILE_MAX_BYTES = 256 * 1024 * 1024
+# Zip stores mtimes at 2 s DOS resolution; the slack keeps the newer-file
+# guard from skipping files over rounding alone.
+_SAVE_MTIME_SLACK = 2.0
+
+
+def _save_data_root() -> Path | None:
+    """Return Dolphin's data dir, honouring a SAVE_DATA_ROOT override."""
+    env = os.environ.get("SAVE_DATA_ROOT")
+    if env:
+        return Path(env)
+    for c in _SAVE_DATA_ROOTS:
+        if c.is_dir():
+            return c
+    return None
+
+
+def _iter_save_files(root: Path) -> list[Path]:
+    """Every regular file under the allowed save subtrees, sorted for a
+    deterministic archive (identical content zips to identical bytes)."""
+    files: list[Path] = []
+    for sub in SAVE_SYNC_SUBTREES:
+        base = root / sub
+        if not base.is_dir():
+            continue
+        files.extend(
+            p for p in sorted(base.rglob("*")) if p.is_file() and not p.is_symlink()
+        )
+    return files
+
+
+def _build_save_archive(baseline: float) -> bytes | None:
+    """Zip every save file modified since the last game launch.
+
+    Returns None when there is nothing to sync — no data dir yet, or no file
+    changed since `baseline`. Member paths are relative to the data dir so a
+    later PUT restores them regardless of which candidate dir is live."""
+    root = _save_data_root()
+    if root is None:
+        log.debug("save-file: no Dolphin data dir found")
+        return None
+    changed: list[Path] = []
+    total = 0
+    for p in _iter_save_files(root):
+        try:
+            st = p.stat()
+        except OSError:
+            continue
+        if st.st_mtime >= baseline:
+            changed.append(p)
+            total += st.st_size
+    if not changed:
+        return None
+    if total > SAVE_FILE_MAX_BYTES:
+        log.warning("save-file: changed saves exceed size limit (%d bytes)", total)
+        return None
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for p in changed:
+            try:
+                zf.write(p, p.relative_to(root).as_posix())
+            except OSError as exc:
+                log.warning("save-file: could not read %s — %s", p, exc)
+    return buf.getvalue()
+
+
+def _mkdirs_owned(path: Path) -> None:
+    """mkdir -p with abc ownership on every directory this call creates, so
+    Dolphin (running as abc) can keep writing saves inside them later."""
+    missing: list[Path] = []
+    cur = path
+    while not cur.exists():
+        missing.append(cur)
+        cur = cur.parent
+    path.mkdir(parents=True, exist_ok=True)
+    for d in reversed(missing):
+        try:
+            os.chown(d, _LOG_UID, _LOG_GID)
+        except OSError:
+            pass
+
+
+def _extract_save_archive(content: bytes) -> tuple[int, int] | str:
+    """Restore a pulled save archive into the data dir.
+
+    Returns (written, skipped) on success, or an error string for a bad
+    archive. Existing files newer than their archive member are skipped so a
+    restore can never roll back saves made since the archive was taken."""
+    root = _save_data_root() or _SAVE_DATA_ROOTS[0]
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(content))
+    except zipfile.BadZipFile:
+        return "body is not a zip archive"
+    with zf:
+        infos = [i for i in zf.infolist() if not i.is_dir()]
+        if sum(i.file_size for i in infos) > SAVE_FILE_MAX_BYTES:
+            return "archive exceeds size limit when extracted"
+        for info in infos:
+            member = PurePosixPath(info.filename)
+            if member.is_absolute() or ".." in member.parts:
+                return f"archive member escapes save dir: {info.filename}"
+            if not any(
+                member.as_posix().startswith(sub + "/") for sub in SAVE_SYNC_SUBTREES
+            ):
+                return f"archive member outside save subtrees: {info.filename}"
+
+        written = skipped = 0
+        for info in infos:
+            target = root / PurePosixPath(info.filename)
+            mtime = time.mktime(info.date_time + (0, 0, -1))
+            try:
+                if (
+                    target.exists()
+                    and target.stat().st_mtime > mtime + _SAVE_MTIME_SLACK
+                ):
+                    skipped += 1
+                    continue
+                _mkdirs_owned(target.parent)
+                tmp = target.parent / f".{target.name}.tmp"
+                tmp.write_bytes(zf.read(info))
+                os.chown(tmp, _LOG_UID, _LOG_GID)
+                os.replace(tmp, target)
+                os.utime(target, (mtime, mtime))
+            except OSError as exc:
+                return f"could not write {info.filename}: {exc}"
+            written += 1
+    return (written, skipped)
+
+
 # ── HTTP handler ──────────────────────────────────────────────────────────────
 
 class BrokerHandler(BaseHTTPRequestHandler):
@@ -803,11 +955,57 @@ class BrokerHandler(BaseHTTPRequestHandler):
         self.wfile.write(content)
         log.info("state-file: served %s (%d bytes)", state_path.name, len(content))
 
+    def _get_save_file(self):
+        with _session_lock:
+            baseline = _session["save_baseline"]
+            rom_name = _session["rom_name"]
+        if baseline is None:
+            self._send_json(404, {"error": "no game has been launched"})
+            return
+        archive = _build_save_archive(baseline)
+        if archive is None:
+            self._send_json(404, {"error": "no save changes since last launch"})
+            return
+        # Header values must be latin-1; ROM stems can be anything.
+        safe_name = "".join(
+            c for c in (rom_name or "dolphin") if c.isascii() and c.isprintable()
+        ).strip() or "dolphin"
+        self.send_response(200)
+        self.send_header("Content-Type", "application/zip")
+        self.send_header("Content-Length", str(len(archive)))
+        self.send_header("X-Save-Filename", f"{safe_name}.saves.zip")
+        self.end_headers()
+        self.wfile.write(archive)
+        log.info("save-file: served archive (%d bytes)", len(archive))
+
+    def _put_save_file(self):
+        try:
+            length = int(self.headers.get("Content-Length", 0))
+        except ValueError:
+            length = 0
+        if length <= 0:
+            self._send_json(400, {"error": "missing or empty body"})
+            return
+        if length > SAVE_FILE_MAX_BYTES:
+            self._send_json(413, {"error": "archive too large"})
+            return
+        content = self.rfile.read(length)
+        result = _extract_save_archive(content)
+        if isinstance(result, str):
+            self._send_json(400, {"error": result})
+            return
+        written, skipped = result
+        log.info("save-file: restored archive — %d written, %d skipped", written, skipped)
+        self._send_json(200, {"status": "ok", "written": written, "skipped": skipped})
+
     def do_PUT(self):
         if not self._check_secret():
             self._send_json(403, {"error": "forbidden"})
             return
         parsed = urlparse(self.path)
+        if parsed.path == "/save-file":
+            self._put_save_file()
+            return
         if parsed.path != "/state-file":
             self._send_json(404, {"error": "not found"})
             return
@@ -869,6 +1067,8 @@ class BrokerHandler(BaseHTTPRequestHandler):
             self._send_json(403, {"error": "forbidden"})
         elif urlparse(self.path).path == "/state-file":
             self._get_state_file()
+        elif urlparse(self.path).path == "/save-file":
+            self._get_save_file()
         elif self.path == "/status":
             with _session_lock:
                 active = (

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,12 @@
+# Lint baseline shared by every RomM integration repo. The ruff version is
+# pinned in .github/workflows/ci.yml so a new ruff release cannot turn CI red
+# on code nobody touched; bump both together.
+line-length = 100
+target-version = "py311"
+
+[lint]
+# E,F,W is clean across all five brokers today. I/UP/B are the natural next
+# step but need a one-off cleanup pass first.
+select = ["E", "F", "W"]
+# Long ini-patch and URL lines are everywhere in the brokers; not worth a reflow.
+ignore = ["E501"]

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,6 +19,7 @@ dir through the `SSTATE_DIR`, `SAVE_DATA_ROOT` and `GCI_CARD_DIR` overrides.
 | `test_memory_card.py` | `/memory-card`: whole-card replace, staging swap, survival of a failed hydrate |
 | `test_state_files.py` | Savestate discovery and the write-confirmation poll |
 | `test_http_api.py` | Live server: routing, auth, slot validation, status codes, round trips |
+| `test_hardening.py` | Zip bombs, planted symlinks, unreadable members, spooling, interrupted card swaps |
 | `test_process_lifecycle.py` | Crash-relaunch backoff and cap, launch serialisation, the display wait |
 | `test_packaging.py` | s6 wiring, sudoers coverage, and drift between `init.sh` and `broker.py` |
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,28 @@
+# Tests
+
+Standard library only, no container, no emulator:
+
+```sh
+python3 -m unittest discover -s tests -t tests
+```
+
+`support.py` imports `root/root/broker.py` under a throwaway module name with
+`PUID`/`PGID` set to the current user, so the module's `chown` calls succeed
+without root. Every test points the broker's data directories at a temporary
+dir through the `SSTATE_DIR`, `SAVE_DATA_ROOT` and `GCI_CARD_DIR` overrides.
+
+| File | Covers |
+|------|--------|
+| `test_rom_path.py` | ROM path validation: traversal, symlink escape, prefix siblings |
+| `test_ini_patch.py` | `Dolphin.ini` patching: section placement, idempotence, no duplicate headers |
+| `test_save_sync.py` | `/save-file`: archive contents, baseline filtering, hostile zip members |
+| `test_memory_card.py` | `/memory-card`: whole-card replace, staging swap, survival of a failed hydrate |
+| `test_state_files.py` | Savestate discovery and the write-confirmation poll |
+| `test_http_api.py` | Live server: routing, auth, slot validation, status codes, round trips |
+| `test_process_lifecycle.py` | Crash-relaunch backoff and cap, launch serialisation, the display wait |
+| `test_packaging.py` | s6 wiring, sudoers coverage, and drift between `init.sh` and `broker.py` |
+
+`test_packaging.py` is the early-warning half. It reads `broker.py` and
+`init.sh` as text and fails when the two copies of the Dolphin defaults
+disagree, when the broker starts shelling out to a binary sudoers does not
+cover, or when a service file stops pointing at a file that exists.

--- a/tests/support.py
+++ b/tests/support.py
@@ -1,0 +1,74 @@
+"""Shared test helpers: import broker.py in isolation and build fixtures."""
+
+import importlib.util
+import io
+import os
+import sys
+import time
+import zipfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BROKER_PATH = REPO_ROOT / "root" / "root" / "broker.py"
+
+
+def _load_broker():
+    """Import broker.py once, with env set so module-level constants are sane.
+
+    PUID/PGID are the current user so the module's chown calls succeed without
+    root; they are otherwise EPERM and every write path returns an error string.
+    """
+    os.environ.setdefault("PUID", str(os.getuid()))
+    os.environ.setdefault("PGID", str(os.getgid()))
+    os.environ.setdefault("BROKER_LOG_LEVEL", "CRITICAL")
+    spec = importlib.util.spec_from_file_location("broker_under_test", BROKER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+broker = _load_broker()
+
+
+def reset_session():
+    """Return the session dict to its post-import state."""
+    with broker._session_lock:
+        broker._session.update(
+            process=None,
+            rom_path=None,
+            rom_name=None,
+            started_at=None,
+            is_managed=False,
+            save_in_progress=False,
+            launch_in_progress=False,
+            save_baseline=None,
+        )
+
+
+def make_zip(members: dict[str, bytes], date_time=(2020, 1, 1, 0, 0, 0)) -> bytes:
+    """Build a zip in memory. Keys are archive member paths."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, data in members.items():
+            info = zipfile.ZipInfo(name, date_time=date_time)
+            zf.writestr(info, data)
+    return buf.getvalue()
+
+
+def zip_names(content: bytes) -> set[str]:
+    with zipfile.ZipFile(io.BytesIO(content)) as zf:
+        return {i.filename for i in zf.infolist() if not i.is_dir()}
+
+
+def write(path: Path, data: bytes = b"x", mtime: float | None = None) -> Path:
+    """Create a file with parents, optionally backdating its mtime."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    if mtime is not None:
+        os.utime(path, (mtime, mtime))
+    return path
+
+
+def past(seconds: float = 3600.0) -> float:
+    return time.time() - seconds

--- a/tests/support.py
+++ b/tests/support.py
@@ -32,7 +32,12 @@ broker = _load_broker()
 
 
 def reset_session():
-    """Return the session dict to its post-import state."""
+    """Return the session dict to its post-import state.
+
+    Every key is listed rather than update()-ing a subset: a leftover
+    relaunch_failures count carries into the next test and changes how many
+    crashes the monitor tolerates there.
+    """
     with broker._session_lock:
         broker._session.update(
             process=None,
@@ -41,8 +46,8 @@ def reset_session():
             started_at=None,
             is_managed=False,
             save_in_progress=False,
-            launch_in_progress=False,
             save_baseline=None,
+            relaunch_failures=0,
         )
 
 

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -1,0 +1,192 @@
+"""Guards against hostile or interrupted input: zip bombs, planted symlinks,
+and a memory-card swap that died halfway through.
+
+These are the paths where a bad archive or a badly timed crash costs the user
+their saves, so each one is pinned to the specific failure it prevents.
+"""
+
+import io
+import os
+import tempfile
+import unittest
+import unittest.mock
+import zipfile
+from pathlib import Path
+
+from support import broker, make_zip, write
+
+
+def lying_zip(name: str, payload: bytes, claimed: int) -> bytes:
+    """A zip whose headers understate a member's real size.
+
+    The declared size is what the cheap up-front sum(file_size) check reads, so
+    a member that lies about it is the archive that gets waved through.
+    """
+    raw = make_zip({name: payload})
+    with zipfile.ZipFile(io.BytesIO(raw)) as zf:
+        real = zf.infolist()[0].file_size
+    # The size appears in both the local header and the central directory, so
+    # patch every occurrence rather than hunting for the two offsets.
+    return raw.replace(real.to_bytes(4, "little"), claimed.to_bytes(4, "little"))
+
+
+class ZipBombs(unittest.TestCase):
+    """A member that decompresses past the limit is refused, not written."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name, "dolphin-emu")
+        self.root.mkdir(parents=True)
+        self.env = unittest.mock.patch.dict(
+            os.environ, {"SAVE_DATA_ROOT": str(self.root)}
+        )
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        self.addCleanup(self.tmp.cleanup)
+
+    def test_a_save_member_over_the_budget_is_refused(self):
+        payload = b"A" * 4096
+        with unittest.mock.patch.object(broker, "SAVE_FILE_MAX_BYTES", 1024):
+            result = broker._extract_save_archive(make_zip({"GC/big.gci": payload}))
+        self.assertIsInstance(result, str)
+        self.assertFalse((self.root / "GC" / "big.gci").exists())
+
+    def test_a_member_that_lies_about_its_size_is_a_rejection_not_a_crash(self):
+        # The cheap sum(file_size) pass sees 1 byte and waves it through, so the
+        # lie is only caught during the read, where zipfile raises BadZipFile.
+        # That has to come back as a refused archive, not an unhandled 500.
+        content = lying_zip("GC/bomb.gci", b"A" * 65536, claimed=1)
+        with unittest.mock.patch.object(broker, "SAVE_FILE_MAX_BYTES", 4096):
+            result = broker._extract_save_archive(content)
+        self.assertIsInstance(result, str)
+        self.assertFalse((self.root / "GC" / "bomb.gci").exists())
+
+    def test_a_card_member_over_the_budget_leaves_the_old_card_intact(self):
+        card = self.root / "romm" / "Card A"
+        write(card / "keep.gci", b"original")
+        with unittest.mock.patch.dict(os.environ, {"GCI_CARD_DIR": str(card)}):
+            with unittest.mock.patch.object(broker, "SAVE_FILE_MAX_BYTES", 1024):
+                result = broker._replace_memory_card(
+                    make_zip({"big.gci": b"A" * 4096})
+                )
+        self.assertIsInstance(result, str)
+        self.assertEqual((card / "keep.gci").read_bytes(), b"original")
+
+
+class SymlinkedDirectories(unittest.TestCase):
+    """A symlinked directory is never descended into when building an archive."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name, "dolphin-emu")
+        self.outside = Path(self.tmp.name, "outside")
+        write(self.outside / "secret.txt", b"not yours")
+        self.root.mkdir(parents=True)
+        self.addCleanup(self.tmp.cleanup)
+
+    def test_the_card_archive_skips_a_planted_symlink(self):
+        card = self.root / "romm" / "Card A"
+        write(card / "real.gci", b"card")
+        (card / "escape").symlink_to(self.outside, target_is_directory=True)
+        with unittest.mock.patch.dict(os.environ, {"GCI_CARD_DIR": str(card)}):
+            archive = broker._build_memory_card_archive()
+        with zipfile.ZipFile(io.BytesIO(archive)) as zf:
+            names = {i.filename for i in zf.infolist()}
+        self.assertEqual(names, {"real.gci"})
+
+    def test_the_save_archive_skips_a_planted_symlink(self):
+        write(self.root / "GC" / "real.gci", b"save")
+        (self.root / "GC" / "escape").symlink_to(self.outside, target_is_directory=True)
+        found = {p.name for p in broker._iter_save_files(self.root)}
+        self.assertEqual(found, {"real.gci"})
+
+    def test_the_screenshot_scan_skips_a_planted_symlink(self):
+        shots = self.root / "ScreenShots"
+        write(shots / "GALE01" / "shot.png", b"png")
+        write(self.outside / "elsewhere.png", b"png")
+        (shots / "escape").symlink_to(self.outside, target_is_directory=True)
+        found = {p.name for p in broker._screenshot_snapshot(shots)}
+        self.assertEqual(found, {"shot.png"})
+
+
+class InterruptedCardSwap(unittest.TestCase):
+    """A card stranded in the backup dir is reclaimed on the next startup."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.card = Path(self.tmp.name, "dolphin-emu", "romm", "Card A")
+        self.backup = self.card.parent / f".{self.card.name}.old"
+        self.env = unittest.mock.patch.dict(
+            os.environ, {"GCI_CARD_DIR": str(self.card)}
+        )
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        self.addCleanup(self.tmp.cleanup)
+
+    def test_the_backup_is_restored_when_no_card_is_present(self):
+        write(self.backup / "save.gci", b"the only copy")
+        broker._recover_memory_card()
+        self.assertEqual((self.card / "save.gci").read_bytes(), b"the only copy")
+        self.assertFalse(self.backup.exists())
+
+    def test_a_live_card_is_never_overwritten_by_a_stale_backup(self):
+        write(self.card / "save.gci", b"live")
+        write(self.backup / "save.gci", b"stale")
+        broker._recover_memory_card()
+        self.assertEqual((self.card / "save.gci").read_bytes(), b"live")
+
+    def test_recovery_is_a_no_op_with_nothing_to_recover(self):
+        broker._recover_memory_card()
+        self.assertFalse(self.card.exists())
+
+
+class SaveIdleWait(unittest.TestCase):
+    """The wait reports whether it succeeded, so callers can refuse to serve."""
+
+    def tearDown(self):
+        with broker._session_lock:
+            broker._session["save_in_progress"] = False
+
+    def test_it_returns_true_when_no_save_is_running(self):
+        with broker._session_lock:
+            broker._session["save_in_progress"] = False
+        self.assertTrue(broker._wait_for_save_idle(broker.time.monotonic() + 1))
+
+    def test_it_returns_false_when_the_save_outlasts_the_deadline(self):
+        with broker._session_lock:
+            broker._session["save_in_progress"] = True
+        self.assertFalse(broker._wait_for_save_idle(broker.time.monotonic() + 0.3))
+
+
+class RelaunchCounter(unittest.TestCase):
+    """The failure count is committed before the backoff sleep, not after."""
+
+    def test_the_count_is_visible_while_the_backoff_is_still_sleeping(self):
+        # A second monitor thread waking during the sleep used to read the old
+        # value, so two crash loops each counted from zero and neither gave up.
+        seen = []
+
+        class FakeProc:
+            def wait(self):
+                return 0
+
+            def poll(self):
+                return 0
+
+        proc = FakeProc()
+        broker._session.update(process=proc, is_managed=True, relaunch_failures=0)
+
+        def record_sleep(_seconds):
+            with broker._session_lock:
+                seen.append(broker._session["relaunch_failures"])
+
+        with unittest.mock.patch.object(broker.time, "sleep", record_sleep):
+            with unittest.mock.patch.object(broker, "_launch_dolphin", lambda *a, **k: None):
+                broker._monitor_process(proc, broker.time.monotonic() - 0.1)
+
+        self.assertEqual(seen, [1])
+        broker._session.update(process=None, is_managed=False, relaunch_failures=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -8,12 +8,13 @@ their saves, so each one is pinned to the specific failure it prevents.
 import io
 import os
 import tempfile
+import time
 import unittest
 import unittest.mock
 import zipfile
 from pathlib import Path
 
-from support import broker, make_zip, write
+from support import broker, make_zip, reset_session, write
 
 
 def lying_zip(name: str, payload: bytes, claimed: int) -> bytes:
@@ -161,6 +162,14 @@ class SaveIdleWait(unittest.TestCase):
 class RelaunchCounter(unittest.TestCase):
     """The failure count is committed before the backoff sleep, not after."""
 
+    def setUp(self):
+        reset_session()
+
+    def tearDown(self):
+        # In tearDown, not at the end of the test body: restoring inline meant a
+        # single failed assertion leaked is_managed=True into every test after it.
+        reset_session()
+
     def test_the_count_is_visible_while_the_backoff_is_still_sleeping(self):
         # A second monitor thread waking during the sleep used to read the old
         # value, so two crash loops each counted from zero and neither gave up.
@@ -174,7 +183,8 @@ class RelaunchCounter(unittest.TestCase):
                 return 0
 
         proc = FakeProc()
-        broker._session.update(process=proc, is_managed=True, relaunch_failures=0)
+        with broker._session_lock:
+            broker._session.update(process=proc, is_managed=True, relaunch_failures=0)
 
         def record_sleep(_seconds):
             with broker._session_lock:
@@ -185,7 +195,204 @@ class RelaunchCounter(unittest.TestCase):
                 broker._monitor_process(proc, broker.time.monotonic() - 0.1)
 
         self.assertEqual(seen, [1])
-        broker._session.update(process=None, is_managed=False, relaunch_failures=0)
+
+
+class UnreadableMembers(unittest.TestCase):
+    """A member this Python cannot decode is the archive's fault, not ours."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name, "dolphin-emu")
+        self.root.mkdir()
+        self.env = unittest.mock.patch.dict(
+            "os.environ", {"SAVE_DATA_ROOT": str(self.root)}
+        )
+        self.env.start()
+
+    def tearDown(self):
+        self.env.stop()
+        self.tmp.cleanup()
+
+    def encrypted(self) -> bytes:
+        """A zip claiming its member is encrypted, by flipping the header bit."""
+        raw = bytearray(make_zip({"GC/a.gci": b"hello"}))
+        for sig, offset in ((b"PK\x03\x04", 6), (b"PK\x01\x02", 8)):
+            at = raw.index(sig)
+            raw[at + offset] |= 0x01
+        return bytes(raw)
+
+    def test_an_encrypted_member_is_a_rejection_not_a_crash(self):
+        # zipfile raises RuntimeError here, which used to escape the handler as
+        # a 500 and leave the staged files on disk.
+        result = broker._extract_save_archive(self.encrypted())
+        self.assertIsInstance(result, str)
+        self.assertIn("unreadable", result)
+
+    def test_an_unsupported_compression_method_is_a_rejection(self):
+        archive = make_zip({"GC/a.gci": b"x"})
+        real_open = zipfile.ZipFile.open
+
+        def unsupported(self, member, mode="r", *args, **kwargs):
+            if mode == "r":
+                raise NotImplementedError("That compression method is not supported")
+            return real_open(self, member, mode, *args, **kwargs)
+
+        with unittest.mock.patch.object(zipfile.ZipFile, "open", unsupported):
+            result = broker._extract_save_archive(archive)
+        self.assertIsInstance(result, str)
+        self.assertIn("unreadable", result)
+
+    def test_a_rejected_archive_leaves_nothing_staged(self):
+        broker._extract_save_archive(self.encrypted())
+        self.assertFalse((self.root / broker.RESTORE_STAGING_DIR).exists())
+
+
+class RestoreStaging(unittest.TestCase):
+    """Staging lives beside the save subtrees, never inside them."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name, "dolphin-emu")
+        self.root.mkdir()
+        self.env = unittest.mock.patch.dict(
+            "os.environ", {"SAVE_DATA_ROOT": str(self.root)}
+        )
+        self.env.start()
+
+    def tearDown(self):
+        self.env.stop()
+        self.tmp.cleanup()
+
+    def test_the_staging_dir_is_outside_every_synced_subtree(self):
+        for sub in broker.SAVE_SYNC_SUBTREES:
+            self.assertFalse(
+                broker.RESTORE_STAGING_DIR.startswith(sub.split("/")[0]),
+                broker.RESTORE_STAGING_DIR,
+            )
+
+    def test_a_successful_restore_leaves_no_staging_dir(self):
+        broker._extract_save_archive(make_zip({"GC/a.gci": b"one"}))
+        self.assertEqual((self.root / "GC" / "a.gci").read_bytes(), b"one")
+        self.assertFalse((self.root / broker.RESTORE_STAGING_DIR).exists())
+
+    def test_leftover_staging_is_never_shipped_back_to_romm(self):
+        # A crash mid-restore used to leave .gci.tmp files among the saves,
+        # where the next GET /save-file zipped them up and sent them onward.
+        stale = self.root / broker.RESTORE_STAGING_DIR / "000000"
+        stale.parent.mkdir(parents=True)
+        stale.write_bytes(b"half a save")
+        write(self.root / "GC" / "real.gci", b"real")
+        names = {p.name for p in broker._iter_save_files(self.root)}
+        self.assertEqual(names, {"real.gci"})
+
+    def slow_extraction(self, seconds=0.05):
+        """Widen the window between staging a member and committing it."""
+        real = broker._extract_member
+
+        def slow(zf, info, dest, budget):
+            time.sleep(seconds)
+            return real(zf, info, dest, budget)
+
+        return unittest.mock.patch.object(broker, "_extract_member", slow)
+
+    def test_two_real_restores_do_not_eat_each_other(self):
+        # Both stage into the same directory and wipe it on entry, so the
+        # second restore used to delete the first one's staged members and
+        # then rename paths that were no longer there.
+        from threading import Thread
+
+        results = {}
+
+        def restore(name, payload):
+            results[name] = broker._extract_save_archive(make_zip({name: payload}))
+
+        with self.slow_extraction():
+            threads = [
+                Thread(target=restore, args=(f"GC/{n}.gci", n.encode() * 8))
+                for n in ("a", "b", "c")
+            ]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=10)
+
+        for name, result in results.items():
+            self.assertIsInstance(result, tuple, f"{name}: {result}")
+        for n in ("a", "b", "c"):
+            self.assertEqual((self.root / "GC" / f"{n}.gci").read_bytes(), n.encode() * 8)
+
+    def test_a_get_never_zips_a_tree_mid_restore(self):
+        # The archive RomM pulls has to be all of the restore or none of it,
+        # never the half of it that had been renamed into place so far.
+        from threading import Thread
+
+        members = {f"GC/{n}.gci": b"restored" for n in ("a", "b", "c")}
+        archives = []
+
+        def restore():
+            broker._extract_save_archive(make_zip(members))
+
+        with self.slow_extraction():
+            worker = Thread(target=restore)
+            worker.start()
+            time.sleep(0.02)
+            archives.append(broker._build_save_archive(0))
+            worker.join(timeout=10)
+
+        with zipfile.ZipFile(io.BytesIO(archives[0])) as zf:
+            self.assertEqual({i.filename for i in zf.infolist()}, set(members))
+
+    def test_a_staging_dir_that_cannot_be_made_names_itself_in_the_error(self):
+        with unittest.mock.patch.object(
+            broker, "_mkdirs_owned", side_effect=OSError("read-only file system")
+        ):
+            error = broker._extract_save_archive(make_zip({"GC/a.gci": b"one"}))
+        self.assertIn(broker.RESTORE_STAGING_DIR, error)
+
+
+class Spool(unittest.TestCase):
+    """Uploads are buffered on the mounted volume, not in the system temp dir."""
+
+    def test_the_spool_dir_is_created_and_used(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp, "spool")
+            with unittest.mock.patch.dict(
+                "os.environ", {"BROKER_SPOOL_DIR": str(target)}
+            ):
+                self.assertEqual(broker._spool_dir(), str(target))
+            self.assertTrue(target.is_dir())
+
+    def test_an_unusable_spool_dir_falls_back_to_the_system_default(self):
+        with unittest.mock.patch.dict(
+            "os.environ", {"BROKER_SPOOL_DIR": "/proc/nope/spool"}
+        ):
+            self.assertIsNone(broker._spool_dir())
+
+    def test_stale_uploads_are_cleared_at_boot(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with unittest.mock.patch.dict("os.environ", {"BROKER_SPOOL_DIR": tmp}):
+                stale = Path(tmp, ".broker-upload-abc123")
+                stale.write_bytes(b"half an archive")
+                keep = Path(tmp, "unrelated")
+                keep.write_bytes(b"x")
+                broker._clear_spool()
+                self.assertFalse(stale.exists())
+                self.assertTrue(keep.exists())
+
+    def test_the_fallback_location_is_cleared_too(self):
+        # An unusable /config is exactly when clearing matters: every upload
+        # has been landing in the system temp dir, which nothing else prunes.
+        with tempfile.TemporaryDirectory() as tmp:
+            stale = Path(tmp, ".broker-upload-def456")
+            stale.write_bytes(b"half an archive")
+            with unittest.mock.patch.dict(
+                "os.environ", {"BROKER_SPOOL_DIR": "/proc/nope/spool"}
+            ):
+                with unittest.mock.patch.object(
+                    broker.tempfile, "gettempdir", lambda: tmp
+                ):
+                    broker._clear_spool()
+            self.assertFalse(stale.exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -1,0 +1,579 @@
+"""The HTTP contract RomM's backend depends on.
+
+Runs a real ThreadingHTTPServer on a loopback port with every emulator-touching
+helper stubbed, so this covers routing, auth, validation and status codes.
+"""
+
+import json
+import tempfile
+import threading
+import unittest
+import unittest.mock
+import urllib.error
+import urllib.request
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+from support import broker, make_zip, reset_session, write, zip_names
+
+
+class Response:
+    def __init__(self, status, headers, body):
+        self.status = status
+        self.headers = headers
+        self.body = body
+
+    def json(self):
+        return json.loads(self.body)
+
+
+class ApiTestCase(unittest.TestCase):
+    """Base: live server, stubbed emulator, isolated dirs."""
+
+    SECRET = "test-secret"
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.data_root = Path(self.tmp.name, "dolphin-emu")
+        self.state_dir = self.data_root / "StateSaves"
+        self.rom_root = Path(self.tmp.name, "library")
+        for d in (self.data_root, self.state_dir, self.rom_root):
+            d.mkdir(parents=True)
+
+        self.env = unittest.mock.patch.dict(
+            "os.environ",
+            {
+                "SAVE_DATA_ROOT": str(self.data_root),
+                "SSTATE_DIR": str(self.state_dir),
+                "GCI_CARD_DIR": str(self.data_root / "romm" / "Card A"),
+            },
+        )
+        self.env.start()
+
+        self.patches = [
+            unittest.mock.patch.object(broker, "SECRET", self.SECRET),
+            unittest.mock.patch.object(broker, "ROM_ROOT", self.rom_root.resolve()),
+            unittest.mock.patch.object(broker, "_launch_dolphin", self._fake_launch),
+            unittest.mock.patch.object(broker, "_xdotool_save_state", lambda slot: True),
+            unittest.mock.patch.object(broker, "_xdotool_load_state", lambda slot: True),
+            unittest.mock.patch.object(broker, "_save_and_exit", lambda slot: True),
+            unittest.mock.patch.object(broker, "_restart_selkies", lambda: None),
+            unittest.mock.patch.object(broker, "_pactl", self._fake_pactl),
+        ]
+        for p in self.patches:
+            p.start()
+
+        self.launches = []
+        self.pactl_calls = []
+        self.pactl_returncode = 0
+
+        reset_session()
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), broker.BrokerHandler)
+        self.port = self.server.server_address[1]
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+        for p in reversed(self.patches):
+            p.stop()
+        self.env.stop()
+        reset_session()
+
+    # ── stubs ─────────────────────────────────────────────────────────────
+
+    def _fake_launch(self, rom_path, state_path=None):
+        self.launches.append((rom_path, state_path))
+
+    def _fake_pactl(self, *args):
+        import subprocess
+
+        self.pactl_calls.append(args)
+        return subprocess.CompletedProcess(
+            list(args), self.pactl_returncode, "Mute: no\n", "pactl said no"
+        )
+
+    # ── request helper ────────────────────────────────────────────────────
+
+    def request(self, method, path, body=None, secret=SECRET, raw=None) -> Response:
+        url = f"http://127.0.0.1:{self.port}{path}"
+        data = raw if raw is not None else (json.dumps(body).encode() if body else None)
+        req = urllib.request.Request(url, data=data, method=method)
+        if secret is not None:
+            req.add_header("X-Broker-Secret", secret)
+        try:
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                return Response(resp.status, dict(resp.headers), resp.read())
+        except urllib.error.HTTPError as exc:
+            with exc:
+                return Response(exc.code, dict(exc.headers), exc.read())
+
+    def start_session(self, rom_name="game.iso"):
+        rom = write(self.rom_root / rom_name)
+        with broker._session_lock:
+            broker._session["rom_path"] = str(rom)
+            broker._session["rom_name"] = rom.stem
+        return rom
+
+
+class Auth(ApiTestCase):
+    def test_health_is_open_for_container_healthchecks(self):
+        resp = self.request("GET", "/health", secret=None)
+        self.assertEqual(resp.status, 200)
+
+    def test_every_other_get_requires_the_secret(self):
+        for path in ("/status", "/state-file", "/save-file", "/memory-card"):
+            with self.subTest(path=path):
+                self.assertEqual(self.request("GET", path, secret=None).status, 403)
+
+    def test_post_requires_the_secret(self):
+        resp = self.request("POST", "/launch", {"rom_path": "/x"}, secret=None)
+        self.assertEqual(resp.status, 403)
+
+    def test_put_requires_the_secret(self):
+        resp = self.request("PUT", "/save-file", raw=b"x", secret=None)
+        self.assertEqual(resp.status, 403)
+
+    def test_delete_requires_the_secret(self):
+        self.assertEqual(self.request("DELETE", "/launch", secret=None).status, 403)
+
+    def test_a_wrong_secret_is_rejected(self):
+        self.assertEqual(self.request("GET", "/status", secret="wrong").status, 403)
+
+    def test_a_secret_prefix_is_rejected(self):
+        self.assertEqual(
+            self.request("GET", "/status", secret=self.SECRET[:-1]).status, 403
+        )
+
+    def test_unknown_routes_are_404(self):
+        for method in ("GET", "POST", "PUT", "DELETE"):
+            with self.subTest(method=method):
+                resp = self.request(method, "/nope", raw=b"")
+                self.assertEqual(resp.status, 404)
+
+
+class Status(ApiTestCase):
+    def test_reports_inactive_with_no_game(self):
+        body = self.request("GET", "/status").json()
+        self.assertFalse(body["active"])
+        self.assertIsNone(body["rom_path"])
+
+    def test_publishes_the_slot_the_broker_actually_uses(self):
+        body = self.request("GET", "/status").json()
+        self.assertEqual(body["save_slot"], broker.SAVE_SLOT)
+        self.assertEqual(body["autosave_slot"], broker.AUTOSAVE_SLOT)
+
+    def test_a_dead_process_is_not_reported_as_active(self):
+        self.start_session()
+        body = self.request("GET", "/status").json()
+        self.assertFalse(body["active"])
+
+
+class Launch(ApiTestCase):
+    def test_launches_a_rom_inside_the_library(self):
+        rom = write(self.rom_root / "game.iso")
+        resp = self.request("POST", "/launch", {"rom_path": str(rom)})
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(resp.json()["status"], "launching")
+
+    def test_requires_a_rom_path(self):
+        self.assertEqual(self.request("POST", "/launch", {}).status, 400)
+        self.assertEqual(
+            self.request("POST", "/launch", {"rom_path": "   "}).status, 400
+        )
+
+    def test_rejects_a_rom_outside_the_library(self):
+        resp = self.request("POST", "/launch", {"rom_path": "/etc/passwd"})
+        self.assertEqual(resp.status, 400)
+        self.assertIn("rom_root", resp.json())
+
+    def test_reports_a_missing_rom_separately_from_a_rejected_one(self):
+        resp = self.request(
+            "POST", "/launch", {"rom_path": str(self.rom_root / "absent.iso")}
+        )
+        self.assertEqual(resp.status, 422)
+
+    def test_rejects_an_out_of_range_load_slot(self):
+        rom = write(self.rom_root / "game.iso")
+        for slot in (-1, broker.MAX_SLOT + 1, "8", 1.5):
+            with self.subTest(slot=slot):
+                resp = self.request(
+                    "POST", "/launch", {"rom_path": str(rom), "load_slot": slot}
+                )
+                self.assertEqual(resp.status, 400)
+
+    def test_load_slot_zero_resolves_to_the_default_slot(self):
+        # Every other route treats 0 as "the default slot"; /launch used to be
+        # the one place it was a 400.
+        rom = write(self.rom_root / "game.iso")
+        write(self.state_dir / f"GALE01.s{broker.SAVE_SLOT:02d}")
+        resp = self.request("POST", "/launch", {"rom_path": str(rom), "load_slot": 0})
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(resp.json()["load_slot"], broker.SAVE_SLOT)
+
+    def test_reports_a_resume_slot_with_no_state_instead_of_booting_unresumed(self):
+        rom = write(self.rom_root / "game.iso")
+        resp = self.request("POST", "/launch", {"rom_path": str(rom), "load_slot": 3})
+        self.assertEqual(resp.status, 404)
+        self.assertEqual(self.launches, [])
+
+    def test_passes_the_resolved_state_file_to_the_launcher(self):
+        rom = write(self.rom_root / "game.iso")
+        state = write(self.state_dir / "GALE01.s03")
+        resp = self.request("POST", "/launch", {"rom_path": str(rom), "load_slot": 3})
+        self.assertEqual(resp.status, 200)
+        self.wait_for_launch()
+        self.assertEqual(self.launches[-1], (str(rom.resolve()), str(state)))
+
+    def test_launch_is_refused_while_a_save_is_in_flight(self):
+        rom = write(self.rom_root / "game.iso")
+        with broker._session_lock:
+            broker._session["save_in_progress"] = True
+        resp = self.request("POST", "/launch", {"rom_path": str(rom)})
+        self.assertEqual(resp.status, 409)
+
+    def test_delete_returns_to_the_dashboard(self):
+        resp = self.request("DELETE", "/launch")
+        self.assertEqual(resp.status, 200)
+        self.wait_for_launch()
+        self.assertEqual(self.launches[-1], (None, None))
+
+    def wait_for_launch(self, timeout=5.0):
+        import time
+
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline and not self.launches:
+            time.sleep(0.02)
+        self.assertTrue(self.launches, "launch thread never ran")
+
+
+class SaveAndLoadState(ApiTestCase):
+    def test_save_state_requires_a_running_game(self):
+        self.assertEqual(self.request("POST", "/save-state", {}).status, 409)
+
+    def test_load_state_requires_a_running_game(self):
+        self.assertEqual(self.request("POST", "/load-state", {}).status, 409)
+
+    def test_save_state_defaults_to_the_configured_slot(self):
+        self.start_session()
+        body = self.request("POST", "/save-state", {}).json()
+        self.assertEqual(body["slot"], broker.SAVE_SLOT)
+
+    def test_slot_zero_means_the_default_slot(self):
+        self.start_session()
+        body = self.request("POST", "/save-state", {"slot": 0}).json()
+        self.assertEqual(body["slot"], broker.SAVE_SLOT)
+
+    def test_rejects_out_of_range_slots(self):
+        self.start_session()
+        for path in ("/save-state", "/load-state", "/save-and-exit"):
+            for slot in (-1, broker.MAX_SLOT + 1, "8", None, 1.5):
+                with self.subTest(path=path, slot=slot):
+                    resp = self.request("POST", path, {"slot": slot})
+                    self.assertEqual(resp.status, 400)
+
+    def test_a_rejected_slot_does_not_leave_the_save_flag_stuck(self):
+        self.start_session()
+        self.request("POST", "/save-state", {"slot": 99})
+        with broker._session_lock:
+            self.assertFalse(broker._session["save_in_progress"])
+        self.assertEqual(self.request("POST", "/save-state", {}).status, 200)
+
+    def test_a_second_save_is_refused_while_one_is_in_flight(self):
+        self.start_session()
+        with broker._session_lock:
+            broker._session["save_in_progress"] = True
+        self.assertEqual(self.request("POST", "/save-state", {}).status, 409)
+        self.assertEqual(self.request("POST", "/save-and-exit", {}).status, 409)
+
+    def test_save_and_exit_reports_the_slot_it_used(self):
+        self.start_session()
+        body = self.request("POST", "/save-and-exit", {"slot": 2}).json()
+        self.assertEqual(body["slot"], 2)
+        self.assertTrue(body["saved"])
+
+    def test_save_and_exit_can_be_queued_without_waiting(self):
+        self.start_session()
+        body = self.request("POST", "/save-and-exit", {"wait": False}).json()
+        self.assertEqual(body["status"], "queued")
+
+
+class Volume(ApiTestCase):
+    def test_sets_a_valid_level(self):
+        resp = self.request("POST", "/volume", {"level": 40})
+        self.assertEqual(resp.status, 200)
+        self.assertIn(("set-sink-volume", "@DEFAULT_SINK@", "40%"), self.pactl_calls)
+
+    def test_accepts_the_range_boundaries(self):
+        for level in (0, 100):
+            with self.subTest(level=level):
+                self.assertEqual(
+                    self.request("POST", "/volume", {"level": level}).status, 200
+                )
+
+    def test_rejects_levels_outside_the_range(self):
+        for level in (-1, 101, "50", None, 50.5):
+            with self.subTest(level=level):
+                self.assertEqual(
+                    self.request("POST", "/volume", {"level": level}).status, 400
+                )
+
+    def test_a_pactl_failure_is_a_500_not_a_dropped_connection(self):
+        self.pactl_returncode = 1
+        self.assertEqual(self.request("POST", "/volume", {"level": 50}).status, 500)
+
+    def test_mute_without_a_body_toggles(self):
+        self.request("POST", "/mute", {})
+        self.assertIn(("set-sink-mute", "@DEFAULT_SINK@", "toggle"), self.pactl_calls)
+
+    def test_mute_with_an_explicit_value_sets_it(self):
+        self.request("POST", "/mute", {"mute": True})
+        self.assertIn(("set-sink-mute", "@DEFAULT_SINK@", "1"), self.pactl_calls)
+
+    def test_a_pactl_mute_failure_is_a_500(self):
+        self.pactl_returncode = 1
+        self.assertEqual(self.request("POST", "/mute", {"mute": True}).status, 500)
+
+
+class StateFileTransfer(ApiTestCase):
+    def test_get_reports_a_slot_with_no_state(self):
+        self.assertEqual(self.request("GET", "/state-file?slot=1").status, 404)
+
+    def test_get_serves_the_state_and_names_it(self):
+        write(self.state_dir / "GALE01.s08", b"statebytes")
+        resp = self.request("GET", "/state-file?slot=8")
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(resp.body, b"statebytes")
+        self.assertEqual(resp.headers["X-State-Filename"], "GALE01.s08")
+
+    def test_get_defaults_to_the_configured_slot(self):
+        write(self.state_dir / f"GALE01.s{broker.SAVE_SLOT:02d}", b"default slot")
+        self.assertEqual(self.request("GET", "/state-file").body, b"default slot")
+
+    def test_get_rejects_a_bad_slot(self):
+        for query in ("?slot=abc", "?slot=-1", f"?slot={broker.MAX_SLOT + 1}"):
+            with self.subTest(query=query):
+                self.assertEqual(
+                    self.request("GET", "/state-file" + query).status, 400
+                )
+
+    def test_get_refuses_an_oversized_state_without_reading_it(self):
+        # The size check used to come after read_bytes, so refusing a 4 GB
+        # state still pulled 4 GB into the broker's address space first.
+        write(self.state_dir / "GALE01.s08", b"far too long")
+        with unittest.mock.patch.object(broker, "STATE_FILE_MAX_BYTES", 4):
+            with unittest.mock.patch.object(
+                Path, "read_bytes", side_effect=AssertionError("read the whole file")
+            ):
+                resp = self.request("GET", "/state-file?slot=8")
+        self.assertEqual(resp.status, 413)
+
+    def test_put_stores_the_file_under_its_original_name(self):
+        resp = self.request(
+            "PUT", "/state-file?filename=GALE01.s08", raw=b"restored"
+        )
+        self.assertEqual(resp.status, 200)
+        self.assertEqual((self.state_dir / "GALE01.s08").read_bytes(), b"restored")
+
+    def test_put_confines_a_traversing_filename_to_the_state_dir(self):
+        self.request("PUT", "/state-file?filename=../../evil.s08", raw=b"x")
+        self.assertFalse(Path(self.tmp.name, "evil.s08").exists())
+        self.assertFalse(self.data_root.joinpath("evil.s08").exists())
+
+    def test_put_rejects_filenames_that_are_not_state_files(self):
+        for name in ("", "Dolphin.ini", "GALE01.sav", ".s08", "GALE01.sXY", "noext"):
+            with self.subTest(name=name):
+                resp = self.request("PUT", f"/state-file?filename={name}", raw=b"x")
+                self.assertEqual(resp.status, 400)
+
+    def test_put_rejects_an_empty_body(self):
+        resp = self.request("PUT", "/state-file?filename=GALE01.s08", raw=b"")
+        self.assertEqual(resp.status, 400)
+
+    def test_put_rejects_an_oversized_body(self):
+        with unittest.mock.patch.object(broker, "STATE_FILE_MAX_BYTES", 4):
+            resp = self.request(
+                "PUT", "/state-file?filename=GALE01.s08", raw=b"far too long"
+            )
+        self.assertEqual(resp.status, 413)
+
+    def test_round_trips_a_state_through_put_then_get(self):
+        self.request("PUT", "/state-file?filename=GALE01.s08", raw=b"round trip")
+        self.assertEqual(self.request("GET", "/state-file?slot=8").body, b"round trip")
+
+
+class SaveFileTransfer(ApiTestCase):
+    def test_get_reports_that_no_game_has_been_launched(self):
+        resp = self.request("GET", "/save-file")
+        self.assertEqual(resp.status, 404)
+        # Tagged so RomM can tell "nothing to sync" apart from an unmarked 404
+        # from an older mod that has no endpoint here at all.
+        self.assertEqual(resp.headers.get("X-Save-File"), "absent")
+
+    def test_get_distinguishes_unchanged_saves_from_an_absent_session(self):
+        import time
+
+        with broker._session_lock:
+            broker._session["save_baseline"] = time.time() + 3600
+        resp = self.request("GET", "/save-file")
+        self.assertEqual(resp.status, 404)
+        self.assertEqual(resp.headers.get("X-Save-File"), "unchanged")
+
+    def test_get_serves_saves_written_since_the_baseline(self):
+        import time
+
+        baseline = time.time()
+        with broker._session_lock:
+            broker._session["save_baseline"] = baseline
+            broker._session["rom_name"] = "Melee"
+        write(self.data_root / "GC" / "save.gci", b"gci", mtime=baseline + 1)
+        resp = self.request("GET", "/save-file")
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(zip_names(resp.body), {"GC/save.gci"})
+        self.assertEqual(resp.headers["X-Save-Filename"], "Melee.saves.zip")
+
+    def test_the_filename_header_survives_a_non_ascii_rom_name(self):
+        import time
+
+        baseline = time.time()
+        with broker._session_lock:
+            broker._session["save_baseline"] = baseline
+            broker._session["rom_name"] = "ポケモン"
+        write(self.data_root / "GC" / "save.gci", b"gci", mtime=baseline + 1)
+        resp = self.request("GET", "/save-file")
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(resp.headers["X-Save-Filename"], "dolphin.saves.zip")
+
+    def test_put_restores_an_archive(self):
+        resp = self.request("PUT", "/save-file", raw=make_zip({"GC/a.gci": b"one"}))
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(resp.json(), {"status": "ok", "written": 1, "skipped": 0})
+
+    def test_put_rejects_an_empty_body(self):
+        self.assertEqual(self.request("PUT", "/save-file", raw=b"").status, 400)
+
+    def test_put_rejects_a_hostile_archive(self):
+        resp = self.request("PUT", "/save-file", raw=make_zip({"/etc/passwd": b"x"}))
+        self.assertEqual(resp.status, 400)
+
+    def test_put_rejects_an_oversized_body(self):
+        with unittest.mock.patch.object(broker, "SAVE_FILE_MAX_BYTES", 4):
+            resp = self.request("PUT", "/save-file", raw=make_zip({"GC/a.gci": b"x"}))
+        self.assertEqual(resp.status, 413)
+
+    def test_put_rejects_a_body_shorter_than_content_length(self):
+        # Raw socket: urllib will not send fewer bytes than it declared, and a
+        # short read used to be handed to the zip parser as a whole archive.
+        import socket
+
+        with socket.create_connection(("127.0.0.1", self.port), timeout=10) as sock:
+            sock.sendall(
+                b"PUT /save-file HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"X-Broker-Secret: " + self.SECRET.encode() + b"\r\n"
+                b"Content-Length: 64\r\n\r\nPK"
+            )
+            sock.shutdown(socket.SHUT_WR)
+            reply = b""
+            while chunk := sock.recv(4096):
+                reply += chunk
+        self.assertIn(b"400", reply.split(b"\r\n")[0])
+        self.assertIn(b"truncated", reply)
+
+
+class MemoryCardTransfer(ApiTestCase):
+    def test_an_absent_card_is_tagged_so_it_is_not_mistaken_for_a_missing_route(self):
+        resp = self.request("GET", "/memory-card")
+        self.assertEqual(resp.status, 404)
+        self.assertEqual(resp.headers.get("X-Memory-Card"), "absent")
+
+    def test_get_serves_the_slot_a_card(self):
+        write(self.data_root / "romm" / "Card A" / "GALE01.gci", b"melee")
+        resp = self.request("GET", "/memory-card")
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(resp.headers["X-Memory-Card-Slot"], "A")
+        self.assertEqual(zip_names(resp.body), {"GALE01.gci"})
+
+    def test_put_hydrates_the_card(self):
+        resp = self.request("PUT", "/memory-card", raw=make_zip({"GALE01.gci": b"m"}))
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(resp.json()["written"], 1)
+
+    def test_put_rejects_an_empty_body(self):
+        self.assertEqual(self.request("PUT", "/memory-card", raw=b"").status, 400)
+
+    def test_put_rejects_a_hostile_archive(self):
+        resp = self.request("PUT", "/memory-card", raw=make_zip({"../x.gci": b"x"}))
+        self.assertEqual(resp.status, 400)
+
+    def test_round_trips_a_card(self):
+        write(self.data_root / "romm" / "Card A" / "GALE01.gci", b"melee")
+        archive = self.request("GET", "/memory-card").body
+        self.request("PUT", "/memory-card", raw=make_zip({"other.gci": b"x"}))
+        self.request("PUT", "/memory-card", raw=archive)
+        card = self.data_root / "romm" / "Card A"
+        self.assertEqual((card / "GALE01.gci").read_bytes(), b"melee")
+        self.assertFalse((card / "other.gci").exists())
+
+
+class StateScreenshot(ApiTestCase):
+    def test_reports_a_slot_with_no_thumbnail(self):
+        self.assertEqual(self.request("GET", "/state-screenshot?slot=1").status, 404)
+
+    def test_serves_the_thumbnail_as_png(self):
+        write(self.data_root / "romm" / "state-shots" / "slot08.png", b"\x89PNG-ish")
+        resp = self.request("GET", "/state-screenshot?slot=8")
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(resp.headers["Content-Type"], "image/png")
+        self.assertEqual(resp.body, b"\x89PNG-ish")
+
+    def test_defaults_to_the_configured_slot(self):
+        name = f"slot{broker.SAVE_SLOT:02d}.png"
+        write(self.data_root / "romm" / "state-shots" / name, b"png")
+        self.assertEqual(self.request("GET", "/state-screenshot").status, 200)
+
+    def test_rejects_a_bad_slot(self):
+        self.assertEqual(self.request("GET", "/state-screenshot?slot=x").status, 400)
+
+
+class MalformedRequests(ApiTestCase):
+    def test_a_body_that_is_not_json_is_rejected_not_defaulted(self):
+        # It used to parse as {}, so a typo'd /launch quietly became a
+        # dashboard reset instead of an error the caller could see.
+        resp = self.request("POST", "/volume", raw=b"{not json")
+        self.assertEqual(resp.status, 400)
+        self.assertIn("JSON", resp.json()["error"])
+        self.assertEqual(self.request("GET", "/health", secret=None).status, 200)
+
+    def test_a_json_body_that_is_not_an_object_is_rejected(self):
+        self.assertEqual(self.request("POST", "/volume", raw=b"[1,2]").status, 400)
+
+    def test_bad_json_on_a_save_route_releases_the_in_progress_flag(self):
+        self.start_session()
+        self.assertEqual(
+            self.request("POST", "/save-state", raw=b"{oops").status, 400
+        )
+        with broker._session_lock:
+            self.assertFalse(broker._session["save_in_progress"])
+        self.assertEqual(self.request("POST", "/save-state", body={}).status, 200)
+
+    def test_a_non_string_rom_path_is_rejected(self):
+        resp = self.request("POST", "/launch", {"rom_path": 42})
+        self.assertEqual(resp.status, 400)
+
+    def test_a_missing_body_does_not_crash_the_handler(self):
+        self.assertEqual(self.request("POST", "/volume", raw=b"").status, 400)
+
+    def test_the_server_survives_every_endpoint_being_called_bodiless(self):
+        paths = ("/cleanup", "/volume", "/mute", "/save-state", "/load-state",
+                 "/save-and-exit", "/launch")
+        for path in paths:
+            with self.subTest(path=path):
+                resp = self.request("POST", path, raw=b"")
+                self.assertLess(resp.status, 500, path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -5,8 +5,10 @@ helper stubbed, so this covers routing, auth, validation and status codes.
 """
 
 import json
+import sys
 import tempfile
 import threading
+import time
 import unittest
 import unittest.mock
 import urllib.error
@@ -382,6 +384,38 @@ class StateFileTransfer(ApiTestCase):
             ):
                 resp = self.request("GET", "/state-file?slot=8")
         self.assertEqual(resp.status, 413)
+
+    def test_a_client_that_hangs_up_mid_pull_does_not_break_the_server(self):
+        # The streamed write is unguarded no longer: a disconnect used to raise
+        # BrokenPipeError out of the handler as an unhandled traceback.
+        # Asserted on handle_error, not on the server still answering: the
+        # server survives an unhandled exception either way, so a /health probe
+        # passed just as well before the guard existed.
+        import socket
+        import struct
+
+        errors = []
+        self.server.handle_error = lambda request, addr: errors.append(
+            sys.exc_info()[1]
+        )
+        # 16 MB so the write is still in progress when the client vanishes, and
+        # SO_LINGER 0 so the close sends an RST rather than a polite FIN: a FIN
+        # alone lets the kernel keep buffering and the write never fails.
+        write(self.state_dir / "GALE01.s08", b"x" * (16 * 1024 * 1024))
+        sock = socket.create_connection(("127.0.0.1", self.port), timeout=10)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0))
+        sock.sendall(
+            b"GET /state-file?slot=8 HTTP/1.1\r\n"
+            b"Host: localhost\r\n"
+            b"X-Broker-Secret: " + self.SECRET.encode() + b"\r\n\r\n"
+        )
+        sock.recv(64)
+        sock.close()
+        self.assertEqual(self.request("GET", "/health", secret=None).status, 200)
+        # The handler runs on its own thread and hits the dead socket a moment
+        # after the close, so give it one before reading the error list.
+        time.sleep(0.5)
+        self.assertEqual(errors, [])
 
     def test_put_stores_the_file_under_its_original_name(self):
         resp = self.request(

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -256,6 +256,19 @@ class SaveAndLoadState(ApiTestCase):
     def test_load_state_requires_a_running_game(self):
         self.assertEqual(self.request("POST", "/load-state", {}).status, 409)
 
+    def test_load_state_is_refused_while_a_save_is_running(self):
+        # Every other slot route already refuses this; a load that lands
+        # mid-save rolls the player back onto the state being overwritten.
+        self.start_session()
+        with broker._session_lock:
+            broker._session["save_in_progress"] = True
+        try:
+            resp = self.request("POST", "/load-state", {})
+        finally:
+            with broker._session_lock:
+                broker._session["save_in_progress"] = False
+        self.assertEqual(resp.status, 409)
+
     def test_save_state_defaults_to_the_configured_slot(self):
         self.start_session()
         body = self.request("POST", "/save-state", {}).json()
@@ -387,6 +400,27 @@ class StateFileTransfer(ApiTestCase):
             with self.subTest(name=name):
                 resp = self.request("PUT", f"/state-file?filename={name}", raw=b"x")
                 self.assertEqual(resp.status, 400)
+
+    def test_put_rejects_a_slot_outside_the_supported_range(self):
+        # .sNN parsed as a slot: .s99 is a well-formed name for a slot nothing
+        # else reads back, so it must not be writable either.
+        for name in ("GALE01.s00", "GALE01.s09", "GALE01.s99"):
+            with self.subTest(name=name):
+                resp = self.request("PUT", f"/state-file?filename={name}", raw=b"x")
+                self.assertEqual(resp.status, 400)
+                self.assertNotIn(name, [p.name for p in self.state_dir.iterdir()])
+
+    def test_get_refuses_to_serve_while_a_save_is_still_running(self):
+        write(self.state_dir / "GALE01.s08", b"state")
+        with broker._session_lock:
+            broker._session["save_in_progress"] = True
+        try:
+            with unittest.mock.patch.object(broker, "STATE_GET_WAIT", 0.3):
+                resp = self.request("GET", "/state-file?slot=8")
+        finally:
+            with broker._session_lock:
+                broker._session["save_in_progress"] = False
+        self.assertEqual(resp.status, 409)
 
     def test_put_rejects_an_empty_body(self):
         resp = self.request("PUT", "/state-file?filename=GALE01.s08", raw=b"")

--- a/tests/test_ini_patch.py
+++ b/tests/test_ini_patch.py
@@ -1,0 +1,184 @@
+"""Dolphin.ini patching.
+
+A key written to the wrong section, or a duplicated section header, silently
+disables hotkeys and controller input. The failure looks like a broken
+emulator, not a broken config, so it is worth pinning hard.
+"""
+
+import re
+import tempfile
+import unittest
+import unittest.mock
+from pathlib import Path
+
+from support import broker
+
+
+def parse_ini(text: str) -> dict[str, dict[str, str]]:
+    """Parse into {section: {key: value}}, last value per key wins."""
+    out: dict[str, dict[str, str]] = {}
+    section = None
+    for line in text.splitlines():
+        s = line.strip()
+        if s.startswith("[") and s.endswith("]"):
+            section = s[1:-1]
+            out.setdefault(section, {})
+        elif "=" in s and section is not None:
+            k, _, v = s.partition("=")
+            out[section][k.strip()] = v.strip()
+    return out
+
+
+def section_headers(text: str) -> list[str]:
+    return re.findall(r"^\[(.+)\]$", text, re.MULTILINE)
+
+
+class IniPatch(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.data_root = Path(self.tmp.name, "data")
+        self.data_root.mkdir()
+        self.ini = Path(self.tmp.name, "config", "dolphin-emu", "Dolphin.ini")
+        self._saved_ini = broker.INI_PATH
+        broker.INI_PATH = self.ini
+        self.env = unittest.mock.patch.dict(
+            "os.environ", {"SAVE_DATA_ROOT": str(self.data_root)}
+        )
+        self.env.start()
+
+    def tearDown(self):
+        self.env.stop()
+        broker.INI_PATH = self._saved_ini
+        self.tmp.cleanup()
+
+    def read(self) -> str:
+        return self.ini.read_text()
+
+    # ── creation ──────────────────────────────────────────────────────────
+
+    def test_creates_ini_when_absent(self):
+        broker._patch_ini()
+        self.assertTrue(self.ini.exists())
+
+    def test_created_ini_matches_the_patch_target(self):
+        """The from-scratch write and the patch target must not drift apart."""
+        broker._patch_ini(fullscreen=True)
+        created = parse_ini(self.read())
+        broker._patch_ini(fullscreen=True)
+        self.assertEqual(created, parse_ini(self.read()))
+
+    # ── section placement ─────────────────────────────────────────────────
+
+    def test_background_input_lands_in_input_section(self):
+        # Dolphin reads MAIN_INPUT_BACKGROUND_INPUT from [Input]. It lived in
+        # [General] until 2026-07-20, where Dolphin never saw it.
+        broker._patch_ini()
+        cfg = parse_ini(self.read())
+        self.assertEqual(cfg["Input"]["BackgroundInput"], "True")
+        self.assertNotIn("BackgroundInput", cfg.get("General", {}))
+
+    def test_hotkeys_require_focus_lands_in_general_section(self):
+        broker._patch_ini()
+        cfg = parse_ini(self.read())
+        self.assertEqual(cfg["General"]["HotkeysRequireFocus"], "False")
+
+    def test_writes_the_key_to_the_right_section_when_it_exists_in_a_wrong_one(self):
+        # The stale [General] copy is left alone; Dolphin does not read it.
+        self.ini.parent.mkdir(parents=True)
+        self.ini.write_text("[General]\nBackgroundInput = False\n")
+        broker._patch_ini()
+        self.assertEqual(parse_ini(self.read())["Input"]["BackgroundInput"], "True")
+
+    # ── patching an existing file ─────────────────────────────────────────
+
+    def test_overwrites_existing_wrong_values(self):
+        self.ini.parent.mkdir(parents=True)
+        self.ini.write_text(
+            "[Core]\nGFXBackend = Vulkan\nCPUThread = True\n"
+            "[Interface]\nConfirmStop = True\n"
+        )
+        broker._patch_ini()
+        cfg = parse_ini(self.read())
+        self.assertEqual(cfg["Core"]["GFXBackend"], "OpenGL")
+        self.assertEqual(cfg["Core"]["CPUThread"], "False")
+        self.assertEqual(cfg["Interface"]["ConfirmStop"], "False")
+
+    def test_preserves_unrelated_keys(self):
+        self.ini.parent.mkdir(parents=True)
+        self.ini.write_text("[Core]\nGFXBackend = Vulkan\nSkipIPL = True\n")
+        broker._patch_ini()
+        self.assertEqual(parse_ini(self.read())["Core"]["SkipIPL"], "True")
+
+    def test_handles_keys_written_without_spaces(self):
+        self.ini.parent.mkdir(parents=True)
+        self.ini.write_text("[Interface]\nConfirmStop=True\n")
+        broker._patch_ini()
+        self.assertEqual(parse_ini(self.read())["Interface"]["ConfirmStop"], "False")
+
+    def test_inserts_missing_key_under_the_existing_header(self):
+        self.ini.parent.mkdir(parents=True)
+        self.ini.write_text("[Interface]\nThemeName = Clean\n")
+        broker._patch_ini()
+        self.assertEqual(section_headers(self.read()).count("Interface"), 1)
+        self.assertEqual(parse_ini(self.read())["Interface"]["ConfirmStop"], "False")
+
+    def test_never_duplicates_a_section_header(self):
+        broker._patch_ini()
+        for _ in range(3):
+            broker._patch_ini()
+        headers = section_headers(self.read())
+        self.assertEqual(len(headers), len(set(headers)), headers)
+
+    def test_is_idempotent(self):
+        broker._patch_ini(fullscreen=True)
+        once = self.read()
+        broker._patch_ini(fullscreen=True)
+        self.assertEqual(once, self.read())
+
+    def test_ends_with_a_newline(self):
+        broker._patch_ini()
+        self.assertTrue(self.read().endswith("\n"))
+        self.assertFalse(self.read().endswith("\n\n\n"))
+
+    def test_leaves_no_temp_file_behind(self):
+        broker._patch_ini()
+        broker._patch_ini()
+        leftovers = [p.name for p in self.ini.parent.iterdir() if ".tmp" in p.name]
+        self.assertEqual(leftovers, [])
+
+    # ── fullscreen and memory card ────────────────────────────────────────
+
+    def test_fullscreen_flag_drives_the_display_section(self):
+        broker._patch_ini(fullscreen=True)
+        self.assertEqual(parse_ini(self.read())["Display"]["Fullscreen"], "True")
+        broker._patch_ini(fullscreen=False)
+        self.assertEqual(parse_ini(self.read())["Display"]["Fullscreen"], "False")
+
+    def test_slot_a_is_pinned_to_the_gci_folder_override(self):
+        broker._patch_ini()
+        cfg = parse_ini(self.read())
+        self.assertEqual(cfg["Core"]["SlotA"], str(broker.EXI_MEMORY_CARD_FOLDER))
+        self.assertEqual(
+            cfg["Core"]["GCIFolderAPathOverride"], str(broker._gci_card_path())
+        )
+
+    def test_analytics_stay_disabled(self):
+        broker._patch_ini()
+        cfg = parse_ini(self.read())
+        self.assertEqual(cfg["Analytics"]["Enabled"], "False")
+        self.assertEqual(cfg["Analytics"]["PermissionAsked"], "True")
+
+    # ── failure handling ──────────────────────────────────────────────────
+
+    def test_unreadable_ini_leaves_the_original_intact(self):
+        self.ini.parent.mkdir(parents=True)
+        self.ini.write_text("[Core]\nGFXBackend = Vulkan\n")
+        with unittest.mock.patch.object(
+            Path, "read_text", side_effect=OSError("boom")
+        ):
+            broker._patch_ini()
+        self.assertIn("Vulkan", self.read())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_memory_card.py
+++ b/tests/test_memory_card.py
@@ -1,0 +1,130 @@
+"""Whole-card GameCube sync.
+
+PUT wipes the live card, so the failure that matters is a hydrate that leaves
+the user with no card at all.
+"""
+
+import tempfile
+import unittest
+import unittest.mock
+from pathlib import Path
+
+from support import broker, make_zip, write, zip_names
+
+
+class MemoryCardBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.card = Path(self.tmp.name, "Card A")
+        self.env = unittest.mock.patch.dict(
+            "os.environ", {"GCI_CARD_DIR": str(self.card)}
+        )
+        self.env.start()
+
+    def tearDown(self):
+        self.env.stop()
+        self.tmp.cleanup()
+
+
+class BuildMemoryCardArchive(MemoryCardBase):
+    def test_returns_none_when_no_card_exists(self):
+        self.assertIsNone(broker._build_memory_card_archive())
+
+    def test_returns_an_error_when_the_card_path_is_a_file(self):
+        write(self.card, b"not a folder")
+        self.assertIsInstance(broker._build_memory_card_archive(), str)
+
+    def test_zips_an_empty_card_directory(self):
+        self.card.mkdir()
+        self.assertEqual(zip_names(broker._build_memory_card_archive()), set())
+
+    def test_member_paths_are_relative_to_the_card_root(self):
+        write(self.card / "USA" / "GALE01.gci", b"melee")
+        self.assertEqual(
+            zip_names(broker._build_memory_card_archive()), {"USA/GALE01.gci"}
+        )
+
+    def test_refuses_to_build_an_oversized_card(self):
+        write(self.card / "big.gci", b"xxxx")
+        with unittest.mock.patch.object(broker, "SAVE_FILE_MAX_BYTES", 1):
+            self.assertIsInstance(broker._build_memory_card_archive(), str)
+
+
+class ReplaceMemoryCard(MemoryCardBase):
+    def test_lays_down_a_card_where_none_existed(self):
+        self.assertEqual(
+            broker._replace_memory_card(make_zip({"GALE01.gci": b"melee"})), (1,)
+        )
+        self.assertEqual((self.card / "GALE01.gci").read_bytes(), b"melee")
+
+    def test_replaces_the_card_wholesale(self):
+        write(self.card / "stale.gci", b"old")
+        broker._replace_memory_card(make_zip({"fresh.gci": b"new"}))
+        self.assertFalse((self.card / "stale.gci").exists())
+        self.assertTrue((self.card / "fresh.gci").exists())
+
+    def test_ignores_local_mtimes_when_hydrating(self):
+        # Unlike /save-file, the card is not merged: the pulled image wins even
+        # when the local file is newer.
+        write(self.card / "GALE01.gci", b"local")
+        broker._replace_memory_card(
+            make_zip({"GALE01.gci": b"pulled"}, date_time=(1990, 1, 1, 0, 0, 0))
+        )
+        self.assertEqual((self.card / "GALE01.gci").read_bytes(), b"pulled")
+
+    def test_rejects_a_body_that_is_not_a_zip(self):
+        self.assertIsInstance(broker._replace_memory_card(b"garbage"), str)
+
+    def test_rejects_absolute_member_paths(self):
+        self.assertIsInstance(
+            broker._replace_memory_card(make_zip({"/etc/passwd": b"x"})), str
+        )
+
+    def test_rejects_dotdot_member_paths(self):
+        self.assertIsInstance(
+            broker._replace_memory_card(make_zip({"../../Dolphin.ini": b"x"})), str
+        )
+
+    def test_rejects_an_archive_that_expands_past_the_size_limit(self):
+        with unittest.mock.patch.object(broker, "SAVE_FILE_MAX_BYTES", 1):
+            self.assertIsInstance(
+                broker._replace_memory_card(make_zip({"a.gci": b"aaaa"})), str
+            )
+
+    def test_a_rejected_archive_leaves_the_existing_card_untouched(self):
+        write(self.card / "GALE01.gci", b"precious")
+        self.assertIsInstance(broker._replace_memory_card(b"garbage"), str)
+        self.assertEqual((self.card / "GALE01.gci").read_bytes(), b"precious")
+
+    def test_the_card_survives_a_failure_partway_through_extraction(self):
+        write(self.card / "GALE01.gci", b"precious")
+        archive = make_zip({"a.gci": b"1", "b.gci": b"2"})
+        real_write_bytes = Path.write_bytes
+        calls = {"n": 0}
+
+        def flaky(self, data):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise OSError("disk full")
+            return real_write_bytes(self, data)
+
+        with unittest.mock.patch.object(Path, "write_bytes", flaky):
+            self.assertIsInstance(broker._replace_memory_card(archive), str)
+        self.assertEqual((self.card / "GALE01.gci").read_bytes(), b"precious")
+
+    def test_leaves_no_staging_directory_behind(self):
+        broker._replace_memory_card(make_zip({"a.gci": b"1"}))
+        leftovers = [p.name for p in self.card.parent.iterdir() if p.name.startswith(".")]
+        self.assertEqual(leftovers, [])
+
+    def test_round_trips_a_built_card(self):
+        write(self.card / "USA" / "GALE01.gci", b"melee")
+        archive = broker._build_memory_card_archive()
+        broker._replace_memory_card(make_zip({"JAP/GALJ01.gci": b"other"}))
+        self.assertEqual(broker._replace_memory_card(archive), (1,))
+        self.assertEqual((self.card / "USA" / "GALE01.gci").read_bytes(), b"melee")
+        self.assertFalse((self.card / "JAP").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_memory_card.py
+++ b/tests/test_memory_card.py
@@ -99,16 +99,17 @@ class ReplaceMemoryCard(MemoryCardBase):
     def test_the_card_survives_a_failure_partway_through_extraction(self):
         write(self.card / "GALE01.gci", b"precious")
         archive = make_zip({"a.gci": b"1", "b.gci": b"2"})
-        real_write_bytes = Path.write_bytes
+        real_open = Path.open
         calls = {"n": 0}
 
-        def flaky(self, data):
-            calls["n"] += 1
-            if calls["n"] == 2:
-                raise OSError("disk full")
-            return real_write_bytes(self, data)
+        def flaky(self, mode="r", *args, **kwargs):
+            if "w" in mode:
+                calls["n"] += 1
+                if calls["n"] == 2:
+                    raise OSError("disk full")
+            return real_open(self, mode, *args, **kwargs)
 
-        with unittest.mock.patch.object(Path, "write_bytes", flaky):
+        with unittest.mock.patch.object(Path, "open", flaky):
             self.assertIsInstance(broker._replace_memory_card(archive), str)
         self.assertEqual((self.card / "GALE01.gci").read_bytes(), b"precious")
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,175 @@
+"""Container wiring and cross-file drift.
+
+None of this is exercised by the unit tests above: it is the layer where the
+mod is a set of files copied into someone else's image. A broken s6 dependency
+or a sudoers rule that no longer covers what the broker shells out to fails at
+runtime, in a container, with no stack trace.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+from support import BROKER_PATH, REPO_ROOT
+
+S6 = REPO_ROOT / "root/etc/s6-overlay/s6-rc.d"
+INIT_SH = S6 / "init-dolphin-config/init.sh"
+BROKER_SRC = BROKER_PATH.read_text()
+INIT_SRC = INIT_SH.read_text()
+
+
+def parse_ini_text(text: str) -> dict[str, dict[str, str]]:
+    out: dict[str, dict[str, str]] = {}
+    section = None
+    for line in text.splitlines():
+        s = line.strip()
+        if s.startswith("[") and s.endswith("]"):
+            section = s[1:-1]
+            out.setdefault(section, {})
+        elif "=" in s and section is not None:
+            k, _, v = s.partition("=")
+            out[section][k.strip()] = v.strip()
+    return out
+
+
+class DockerMod(unittest.TestCase):
+    def test_the_image_is_just_the_root_overlay(self):
+        text = (REPO_ROOT / "Dockerfile").read_text()
+        self.assertIn("FROM scratch", text)
+        self.assertIn("COPY root/", text)
+
+    def test_compiled_python_is_not_shipped(self):
+        ignored = (REPO_ROOT / ".gitignore").read_text()
+        self.assertIn("__pycache__", ignored)
+        self.assertIn("*.pyc", ignored)
+
+
+class S6Services(unittest.TestCase):
+    def test_the_broker_is_a_longrun_and_the_config_step_is_a_oneshot(self):
+        self.assertEqual((S6 / "svc-broker/type").read_text().strip(), "longrun")
+        self.assertEqual(
+            (S6 / "init-dolphin-config/type").read_text().strip(), "oneshot"
+        )
+
+    def test_both_services_are_enabled_in_the_user_bundle(self):
+        enabled = {p.name for p in (S6 / "user/contents.d").iterdir()}
+        self.assertEqual(enabled, {"svc-broker", "init-dolphin-config"})
+
+    def test_the_broker_waits_for_the_config_step(self):
+        deps = {p.name for p in (S6 / "svc-broker/dependencies.d").iterdir()}
+        self.assertIn("init-dolphin-config", deps)
+
+    def test_the_oneshot_up_file_points_at_the_script_that_exists(self):
+        up = (S6 / "init-dolphin-config/up").read_text().strip()
+        self.assertTrue(Path(REPO_ROOT / "root" / up.lstrip("/")).is_file(), up)
+
+    def test_the_run_script_execs_the_broker_that_ships(self):
+        run = (S6 / "svc-broker/run").read_text()
+        self.assertIn("/root/broker.py", run)
+        self.assertTrue(BROKER_PATH.is_file())
+
+    def test_the_broker_runs_unbuffered_so_logs_reach_s6(self):
+        self.assertIn("python3 -u", (S6 / "svc-broker/run").read_text())
+
+
+class Sudoers(unittest.TestCase):
+    RULE = (REPO_ROOT / "root/etc/sudoers.d/broker").read_text()
+
+    def test_the_rule_targets_the_abc_account(self):
+        self.assertRegex(self.RULE, r"^root ALL=\(abc\) NOPASSWD:", )
+
+    def test_every_binary_the_broker_sudos_to_is_covered(self):
+        invoked = set(re.findall(r'"sudo", "-u", "abc", "(\w+)"', BROKER_SRC))
+        self.assertTrue(invoked, "no sudo invocations found, did the pattern change?")
+        for binary in invoked:
+            with self.subTest(binary=binary):
+                self.assertIn(f"/{binary}", self.RULE)
+
+    def test_the_rule_is_made_readable_by_sudo_at_init(self):
+        # sudo silently ignores a sudoers.d file that is not mode 0440.
+        self.assertIn("chmod 0440 /etc/sudoers.d/broker", INIT_SRC)
+
+
+class SeededConfigMatchesTheBroker(unittest.TestCase):
+    """init.sh pre-seeds Dolphin.ini and broker.py patches it.
+
+    Two copies of the same defaults drift: BackgroundInput sat in the wrong
+    section in both until 2026-07-20, and only one of them was fixed.
+    """
+
+    def setUp(self):
+        match = re.search(r"cat > \"\$DOLPHIN_INI\" <<'EOF'\n(.*?)\nEOF", INIT_SRC, re.S)
+        if match is None:
+            self.skipTest("init.sh no longer seeds Dolphin.ini, broker.py is the only copy")
+        self.seeded = parse_ini_text(match.group(1))
+
+    def broker_target(self) -> dict[str, dict[str, str]]:
+        """The section/key pairs broker.py enforces, read from its own source."""
+        body = re.search(r"\n    target = \{\n(.*?)\n    \}\n", BROKER_SRC, re.S)
+        self.assertIsNotNone(body, "broker.py target dict not found")
+        out: dict[str, dict[str, str]] = {}
+        for section_name, keys in re.findall(
+            r'"(\w+)": \{([^}]*)\}', body.group(1), re.S
+        ):
+            out[section_name] = {
+                k: v for k, v in re.findall(r'"(\w+)": ["\w.]*?"?(\w+)"', keys)
+            }
+        return {s: set(k) for s, k in out.items()}
+
+    def test_no_seeded_key_sits_in_a_section_the_broker_disagrees_with(self):
+        target = self.broker_target()
+        placement = {k: s for s, keys in target.items() for k in keys}
+        for section, keys in self.seeded.items():
+            for key in keys:
+                with self.subTest(key=key):
+                    expected = placement.get(key)
+                    if expected is None:
+                        continue
+                    self.assertEqual(
+                        section,
+                        expected,
+                        f"init.sh puts {key} in [{section}], broker.py in [{expected}]",
+                    )
+
+    def test_seeded_values_match_what_the_broker_enforces(self):
+        # A seeded value the broker immediately overwrites is dead weight and a
+        # misleading record of what the mod wants.
+        for section, keys in self.seeded.items():
+            for key, value in keys.items():
+                with self.subTest(key=key):
+                    match = re.search(
+                        rf'"{key}":\s*("(\w+)"|str\(|f?"?\{{)', BROKER_SRC
+                    )
+                    if match is None or match.group(2) is None:
+                        continue
+                    self.assertEqual(value, match.group(2))
+
+
+class BrokerConstants(unittest.TestCase):
+    def test_the_save_slot_is_within_the_hotkey_range(self):
+        from support import broker
+
+        self.assertLessEqual(broker.MAX_SLOT, 8, "Dolphin only maps F1-F8")
+        self.assertTrue(1 <= broker.SAVE_SLOT <= broker.MAX_SLOT)
+
+    def test_the_state_and_save_roots_share_a_parent(self):
+        """Screenshots, cards and states must resolve under the same data dir.
+
+        _sstate_dir and _save_data_root probe independently; if their candidate
+        lists ever stop lining up, a state can land in one tree and its
+        thumbnail in the other.
+        """
+        from support import broker
+
+        state_parents = [c.parent for c in broker._SSTATE_DIR_CANDIDATES]
+        self.assertEqual(list(broker._SAVE_DATA_ROOTS), state_parents)
+
+    def test_the_declared_save_subtrees_include_the_pinned_card(self):
+        from support import broker
+
+        self.assertIn("romm/Card A", broker.SAVE_SYNC_SUBTREES)
+        self.assertTrue(str(broker._gci_card_path()).endswith("romm/Card A"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_process_lifecycle.py
+++ b/tests/test_process_lifecycle.py
@@ -95,6 +95,18 @@ class CrashRelaunch(unittest.TestCase):
         self.monitor(0.1)
         self.assertEqual(self.relaunches, 0)
 
+    def test_a_launch_during_the_backoff_is_not_stomped_on(self):
+        # The monitor sleeps up to a minute. A /launch landing in that window
+        # installs a new process, and a monitor that only rechecked is_managed
+        # went on to relaunch the dashboard over the game just started.
+        def launch_lands(_seconds):
+            with broker._session_lock:
+                broker._session["process"] = FakeProc(pid=777)
+
+        with unittest.mock.patch.object(broker.time, "sleep", launch_lands):
+            self.monitor(0.1)
+        self.assertEqual(self.relaunches, 0)
+
     def test_a_superseded_process_is_not_relaunched(self):
         with broker._session_lock:
             broker._session["process"] = FakeProc(pid=9999)

--- a/tests/test_process_lifecycle.py
+++ b/tests/test_process_lifecycle.py
@@ -1,0 +1,151 @@
+"""Dolphin's lifecycle: crash relaunch, launch serialisation, display wait.
+
+None of this has an HTTP surface, and all of it fails the same way in
+production: the stream goes black and the logs fill with identical lines.
+"""
+
+import time
+import unittest
+import unittest.mock
+from pathlib import Path
+
+from support import broker, reset_session
+
+
+class FakeProc:
+    def __init__(self, pid=4242):
+        self.pid = pid
+
+    def wait(self):
+        return 0
+
+    def poll(self):
+        return 0
+
+
+class CrashRelaunch(unittest.TestCase):
+    """_monitor_process respawns the dashboard, but must not do so forever."""
+
+    def setUp(self):
+        reset_session()
+        self.proc = FakeProc()
+        with broker._session_lock:
+            broker._session["process"] = self.proc
+            broker._session["is_managed"] = True
+        self.relaunches = 0
+        self.sleeps = []
+        self.patches = [
+            unittest.mock.patch.object(broker, "_launch_dolphin", self._relaunch),
+            unittest.mock.patch.object(broker.time, "sleep", self.sleeps.append),
+        ]
+        for p in self.patches:
+            p.start()
+
+    def tearDown(self):
+        for p in reversed(self.patches):
+            p.stop()
+        reset_session()
+
+    def _relaunch(self, rom_path, state_path=None):
+        self.relaunches += 1
+
+    def monitor(self, lifetime):
+        """Run one _monitor_process cycle for a process that lived `lifetime`."""
+        broker._monitor_process(self.proc, time.monotonic() - lifetime)
+
+    def test_a_healthy_exit_relaunches_promptly(self):
+        self.monitor(broker.RELAUNCH_HEALTHY_SECONDS + 1)
+        self.assertEqual(self.relaunches, 1)
+        self.assertEqual(self.sleeps, [1])
+
+    def test_a_healthy_exit_clears_earlier_failures(self):
+        with broker._session_lock:
+            broker._session["relaunch_failures"] = 3
+        self.monitor(broker.RELAUNCH_HEALTHY_SECONDS + 1)
+        with broker._session_lock:
+            self.assertEqual(broker._session["relaunch_failures"], 0)
+
+    def test_repeated_instant_exits_back_off(self):
+        waits = []
+        for _ in range(3):
+            self.sleeps.clear()
+            self.monitor(0.1)
+            waits.append(self.sleeps[0])
+        self.assertEqual(waits, sorted(waits))
+        self.assertLess(waits[0], waits[-1])
+
+    def test_the_backoff_is_capped(self):
+        with broker._session_lock:
+            broker._session["relaunch_failures"] = broker.RELAUNCH_MAX_FAILURES - 1
+        self.monitor(0.1)
+        self.assertLessEqual(self.sleeps[0], broker.RELAUNCH_BACKOFF_CAP)
+
+    def test_a_crash_loop_is_eventually_abandoned(self):
+        # Uncapped, a Dolphin that dies on startup respawned forever and buried
+        # the reason under thousands of identical log lines.
+        for _ in range(broker.RELAUNCH_MAX_FAILURES + 2):
+            self.monitor(0.1)
+        self.assertEqual(self.relaunches, broker.RELAUNCH_MAX_FAILURES)
+        with broker._session_lock:
+            self.assertFalse(broker._session["is_managed"])
+
+    def test_an_unmanaged_session_is_not_relaunched(self):
+        with broker._session_lock:
+            broker._session["is_managed"] = False
+        self.monitor(0.1)
+        self.assertEqual(self.relaunches, 0)
+
+    def test_a_superseded_process_is_not_relaunched(self):
+        with broker._session_lock:
+            broker._session["process"] = FakeProc(pid=9999)
+        self.monitor(0.1)
+        self.assertEqual(self.relaunches, 0)
+
+
+class LaunchSerialisation(unittest.TestCase):
+    def test_launches_do_not_interleave(self):
+        # Two concurrent /launch requests used to interleave their
+        # kill/patch/spawn steps and leave two Dolphins running, or none.
+        from threading import Thread
+
+        overlaps = []
+        active = []
+
+        def slow_inner(rom_path, state_path=None):
+            active.append(rom_path)
+            overlaps.append(len(active))
+            time.sleep(0.05)
+            active.pop()
+
+        with unittest.mock.patch.object(
+            broker, "_launch_dolphin_locked", slow_inner
+        ):
+            threads = [
+                Thread(target=broker._launch_dolphin, args=(f"rom{i}",))
+                for i in range(4)
+            ]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=5)
+
+        self.assertEqual(overlaps, [1, 1, 1, 1])
+
+
+class DisplayWait(unittest.TestCase):
+    """The broker used to sleep a flat 5 s and hope the desktop was up."""
+
+    def test_returns_as_soon_as_the_x_socket_exists(self):
+        with unittest.mock.patch.object(Path, "exists", lambda self: True):
+            started = time.monotonic()
+            self.assertTrue(broker._wait_for_display(timeout=5))
+        self.assertLess(time.monotonic() - started, 1)
+
+    def test_gives_up_and_starts_anyway(self):
+        # Starting without a display is better than never answering /health.
+        with unittest.mock.patch.object(Path, "exists", lambda self: False):
+            self.assertFalse(broker._wait_for_display(timeout=0.3))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rom_path.py
+++ b/tests/test_rom_path.py
@@ -1,0 +1,61 @@
+"""ROM path validation: the boundary between RomM's input and the exec line."""
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from support import broker
+
+
+class RomPathValidation(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name, "library")
+        self.root.mkdir()
+        self.outside = Path(self.tmp.name, "secrets")
+        self.outside.mkdir()
+        self._saved_root = broker.ROM_ROOT
+        broker.ROM_ROOT = self.root.resolve()
+
+    def tearDown(self):
+        broker.ROM_ROOT = self._saved_root
+        self.tmp.cleanup()
+
+    def test_accepts_path_inside_root(self):
+        rom = self.root / "gc" / "game.iso"
+        rom.parent.mkdir()
+        rom.touch()
+        self.assertEqual(broker._validate_rom_path(str(rom)), rom.resolve())
+
+    def test_rejects_dotdot_traversal(self):
+        self.assertIsNone(
+            broker._validate_rom_path(str(self.root / ".." / "secrets" / "key"))
+        )
+
+    def test_rejects_absolute_path_outside_root(self):
+        self.assertIsNone(broker._validate_rom_path("/etc/passwd"))
+
+    def test_rejects_symlink_escaping_root(self):
+        link = self.root / "escape.iso"
+        target = self.outside / "key"
+        target.touch()
+        os.symlink(target, link)
+        self.assertIsNone(broker._validate_rom_path(str(link)))
+
+    def test_rejects_sibling_directory_with_shared_prefix(self):
+        sibling = Path(str(self.root) + "-other")
+        sibling.mkdir()
+        self.assertIsNone(broker._validate_rom_path(str(sibling / "game.iso")))
+
+    def test_accepts_path_that_does_not_exist_yet(self):
+        # Existence is checked separately by the handler, which returns 422.
+        missing = self.root / "nope.iso"
+        self.assertEqual(broker._validate_rom_path(str(missing)), missing)
+
+    def test_rejects_embedded_nul(self):
+        self.assertIsNone(broker._validate_rom_path(str(self.root / "a\0b.iso")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_save_sync.py
+++ b/tests/test_save_sync.py
@@ -1,0 +1,187 @@
+"""In-game save sync: GET builds an archive, PUT restores one.
+
+PUT extracts an attacker-influenced zip while running as root, so the member
+checks get the most attention here.
+"""
+
+import os
+import tempfile
+import time
+import unittest
+import unittest.mock
+from pathlib import Path
+
+from support import broker, make_zip, past, write, zip_names
+
+
+class SaveSyncBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name, "dolphin-emu")
+        self.root.mkdir()
+        self.env = unittest.mock.patch.dict(
+            "os.environ", {"SAVE_DATA_ROOT": str(self.root)}
+        )
+        self.env.start()
+
+    def tearDown(self):
+        self.env.stop()
+        self.tmp.cleanup()
+
+
+class BuildSaveArchive(SaveSyncBase):
+    def test_returns_none_when_nothing_changed_since_baseline(self):
+        write(self.root / "GC" / "USA" / "Card A" / "old.gci", mtime=past())
+        self.assertIsNone(broker._build_save_archive(time.time()))
+
+    def test_includes_only_files_modified_since_baseline(self):
+        baseline = time.time()
+        write(self.root / "GC" / "stale.gci", mtime=past())
+        write(self.root / "GC" / "fresh.gci", mtime=baseline + 1)
+        archive = broker._build_save_archive(baseline)
+        self.assertEqual(zip_names(archive), {"GC/fresh.gci"})
+
+    def test_covers_every_declared_subtree(self):
+        baseline = time.time()
+        for sub in broker.SAVE_SYNC_SUBTREES:
+            write(self.root / sub / "f.bin", mtime=baseline + 1)
+        archive = broker._build_save_archive(baseline)
+        self.assertEqual(
+            zip_names(archive),
+            {f"{sub}/f.bin" for sub in broker.SAVE_SYNC_SUBTREES},
+        )
+
+    def test_ignores_files_outside_the_declared_subtrees(self):
+        baseline = time.time()
+        write(self.root / "Config" / "Dolphin.ini", mtime=baseline + 1)
+        write(self.root / "StateSaves" / "GALE01.s08", mtime=baseline + 1)
+        self.assertIsNone(broker._build_save_archive(baseline))
+
+    def test_member_paths_are_relative_to_the_data_root(self):
+        baseline = time.time()
+        write(self.root / "Wii" / "title" / "00010000" / "save.bin", mtime=baseline + 1)
+        self.assertEqual(
+            zip_names(broker._build_save_archive(baseline)),
+            {"Wii/title/00010000/save.bin"},
+        )
+
+    def test_identical_content_produces_identical_bytes(self):
+        baseline = time.time()
+        for name in ("b.gci", "a.gci", "c.gci"):
+            write(self.root / "GC" / name, b"data", mtime=baseline + 1)
+        first = broker._build_save_archive(baseline)
+        second = broker._build_save_archive(baseline)
+        self.assertEqual(first, second)
+
+    def test_skips_symlinked_files(self):
+        baseline = time.time()
+        secret = write(Path(self.tmp.name, "secret.key"), b"s", mtime=baseline + 1)
+        (self.root / "GC").mkdir()
+        os.symlink(secret, self.root / "GC" / "link.gci")
+        self.assertIsNone(broker._build_save_archive(baseline))
+
+    def test_refuses_to_build_an_oversized_archive(self):
+        baseline = time.time()
+        write(self.root / "GC" / "big.gci", b"x", mtime=baseline + 1)
+        with unittest.mock.patch.object(broker, "SAVE_FILE_MAX_BYTES", 0):
+            self.assertIsNone(broker._build_save_archive(baseline))
+
+    def test_returns_none_when_no_data_dir_exists(self):
+        with unittest.mock.patch.dict(
+            "os.environ", {"SAVE_DATA_ROOT": str(Path(self.tmp.name, "missing"))}
+        ):
+            self.assertIsNone(broker._build_save_archive(0))
+
+
+class ExtractSaveArchive(SaveSyncBase):
+    def test_restores_members_into_the_data_root(self):
+        result = broker._extract_save_archive(make_zip({"GC/save.gci": b"hello"}))
+        self.assertEqual(result, (1, 0))
+        self.assertEqual((self.root / "GC" / "save.gci").read_bytes(), b"hello")
+
+    def test_creates_missing_parent_directories(self):
+        broker._extract_save_archive(
+            make_zip({"Wii/title/00010000/00000001/data/save.bin": b"w"})
+        )
+        self.assertTrue(
+            (self.root / "Wii/title/00010000/00000001/data/save.bin").exists()
+        )
+
+    def test_rejects_a_body_that_is_not_a_zip(self):
+        self.assertIsInstance(broker._extract_save_archive(b"not a zip"), str)
+
+    def test_rejects_absolute_member_paths(self):
+        result = broker._extract_save_archive(make_zip({"/etc/passwd": b"pwned"}))
+        self.assertIsInstance(result, str)
+
+    def test_rejects_dotdot_member_paths(self):
+        result = broker._extract_save_archive(
+            make_zip({"GC/../../.config/dolphin-emu/Dolphin.ini": b"pwned"})
+        )
+        self.assertIsInstance(result, str)
+
+    def test_rejects_members_outside_the_declared_subtrees(self):
+        for name in ("StateSaves/GALE01.s08", "Config/Dolphin.ini", "keys.bin"):
+            with self.subTest(member=name):
+                self.assertIsInstance(
+                    broker._extract_save_archive(make_zip({name: b"x"})), str
+                )
+
+    def test_rejects_a_subtree_name_used_as_a_prefix(self):
+        # "GC" must not authorise "GCevil/".
+        self.assertIsInstance(
+            broker._extract_save_archive(make_zip({"GCevil/x.bin": b"x"})), str
+        )
+
+    def test_rejects_an_archive_that_expands_past_the_size_limit(self):
+        with unittest.mock.patch.object(broker, "SAVE_FILE_MAX_BYTES", 1):
+            self.assertIsInstance(
+                broker._extract_save_archive(make_zip({"GC/a.gci": b"aaaa"})), str
+            )
+
+    def test_writes_nothing_when_any_member_is_rejected(self):
+        content = make_zip({"GC/good.gci": b"ok", "/etc/passwd": b"pwned"})
+        self.assertIsInstance(broker._extract_save_archive(content), str)
+        self.assertFalse((self.root / "GC" / "good.gci").exists())
+
+    def test_skips_local_files_newer_than_the_archive_member(self):
+        target = write(self.root / "GC" / "save.gci", b"newer", mtime=time.time())
+        result = broker._extract_save_archive(
+            make_zip({"GC/save.gci": b"older"}, date_time=(2020, 1, 1, 0, 0, 0))
+        )
+        self.assertEqual(result, (0, 1))
+        self.assertEqual(target.read_bytes(), b"newer")
+
+    def test_overwrites_local_files_older_than_the_archive_member(self):
+        ancient = time.mktime((2010, 1, 1, 0, 0, 0, 0, 0, -1))
+        target = write(self.root / "GC" / "save.gci", b"older", mtime=ancient)
+        result = broker._extract_save_archive(make_zip({"GC/save.gci": b"newer"}))
+        self.assertEqual(result, (1, 0))
+        self.assertEqual(target.read_bytes(), b"newer")
+
+    def test_restored_mtime_matches_the_archive_member(self):
+        broker._extract_save_archive(
+            make_zip({"GC/save.gci": b"x"}, date_time=(2021, 6, 1, 12, 0, 0))
+        )
+        stat = (self.root / "GC" / "save.gci").stat()
+        expected = time.mktime((2021, 6, 1, 12, 0, 0, 0, 0, -1))
+        self.assertAlmostEqual(stat.st_mtime, expected, delta=2)
+
+    def test_leaves_no_temp_file_behind(self):
+        broker._extract_save_archive(make_zip({"GC/save.gci": b"x"}))
+        leftovers = [p.name for p in (self.root / "GC").iterdir() if ".tmp" in p.name]
+        self.assertEqual(leftovers, [])
+
+    def test_round_trips_a_built_archive(self):
+        baseline = time.time()
+        write(self.root / "GC" / "a.gci", b"one", mtime=baseline + 1)
+        write(self.root / "Wii" / "title" / "b.bin", b"two", mtime=baseline + 1)
+        archive = broker._build_save_archive(baseline)
+        for p in (self.root / "GC" / "a.gci", self.root / "Wii" / "title" / "b.bin"):
+            p.unlink()
+        self.assertEqual(broker._extract_save_archive(archive), (2, 0))
+        self.assertEqual((self.root / "GC" / "a.gci").read_bytes(), b"one")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_state_files.py
+++ b/tests/test_state_files.py
@@ -1,0 +1,142 @@
+"""Savestate discovery and write confirmation.
+
+Confirming the write is what stops a kill landing mid-flush and truncating the
+state, so the slot-matching and stability rules are pinned here.
+"""
+
+import tempfile
+import threading
+import time
+import unittest
+import unittest.mock
+from pathlib import Path
+
+from support import broker, write
+
+
+class StateDirResolution(unittest.TestCase):
+    def test_env_override_wins_over_the_probed_candidates(self):
+        with unittest.mock.patch.dict("os.environ", {"SSTATE_DIR": "/custom/states"}):
+            self.assertEqual(broker._sstate_dir(), Path("/custom/states"))
+
+    def test_returns_none_when_no_candidate_exists(self):
+        with unittest.mock.patch.dict("os.environ", {}, clear=False):
+            with unittest.mock.patch.object(
+                broker, "_SSTATE_DIR_CANDIDATES", (Path("/nope/a"), Path("/nope/b"))
+            ):
+                self.assertIsNone(broker._sstate_dir())
+
+
+class NewestStateForSlot(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self.env = unittest.mock.patch.dict(
+            "os.environ", {"SSTATE_DIR": str(self.dir)}
+        )
+        self.env.start()
+
+    def tearDown(self):
+        self.env.stop()
+        self.tmp.cleanup()
+
+    def test_returns_none_when_the_slot_has_no_state(self):
+        self.assertIsNone(broker._newest_state_for_slot(8))
+
+    def test_matches_the_slot_suffix_exactly(self):
+        write(self.dir / "GALE01.s08")
+        self.assertIsNone(broker._newest_state_for_slot(1))
+        self.assertIsNotNone(broker._newest_state_for_slot(8))
+
+    def test_slot_is_zero_padded_to_two_digits(self):
+        write(self.dir / "GALE01.s1")
+        self.assertIsNone(broker._newest_state_for_slot(1))
+        write(self.dir / "GALE01.s01")
+        self.assertIsNotNone(broker._newest_state_for_slot(1))
+
+    def test_picks_the_newest_when_several_games_share_a_slot(self):
+        write(self.dir / "OLD001.s08", mtime=time.time() - 600)
+        newest = write(self.dir / "NEW001.s08", mtime=time.time())
+        self.assertEqual(broker._newest_state_for_slot(8), newest)
+
+    def test_ignores_the_undo_backup(self):
+        write(self.dir / "lastState.sav")
+        self.assertIsNone(broker._newest_state_for_slot(8))
+
+
+class WaitForStateWrite(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def wait(self, before, timeout=3.0, slot=8):
+        return broker._wait_for_sstate_write(
+            self.dir, before, time.monotonic() + timeout, slot
+        )
+
+    def test_times_out_when_nothing_is_written(self):
+        self.assertFalse(self.wait(broker._sstate_snapshot(self.dir), timeout=0.5))
+
+    def test_confirms_a_newly_created_state(self):
+        before = broker._sstate_snapshot(self.dir)
+        write(self.dir / "GALE01.s08", b"state")
+        self.assertTrue(self.wait(before))
+
+    def test_confirms_an_overwrite_of_an_existing_state(self):
+        target = write(self.dir / "GALE01.s08", b"old", mtime=time.time() - 600)
+        before = broker._sstate_snapshot(self.dir)
+        write(target, b"new")
+        self.assertTrue(self.wait(before))
+
+    def test_ignores_writes_to_other_slots(self):
+        before = broker._sstate_snapshot(self.dir)
+        write(self.dir / "GALE01.s01", b"other slot")
+        self.assertFalse(self.wait(before, timeout=0.8, slot=8))
+
+    def test_ignores_the_undo_backup_file(self):
+        before = broker._sstate_snapshot(self.dir)
+        write(self.dir / "lastState.sav", b"undo")
+        self.assertFalse(self.wait(before, timeout=0.8))
+
+    def test_waits_for_the_size_to_stop_growing(self):
+        target = self.dir / "GALE01.s08"
+        before = broker._sstate_snapshot(self.dir)
+        stop = threading.Event()
+
+        def grow():
+            data = b""
+            for _ in range(6):
+                if stop.is_set():
+                    return
+                data += b"x" * 1024
+                target.write_bytes(data)
+                time.sleep(0.15)
+
+        writer = threading.Thread(target=grow, daemon=True)
+        start = time.monotonic()
+        writer.start()
+        confirmed = self.wait(before, timeout=5.0)
+        stop.set()
+        writer.join(timeout=2)
+        self.assertTrue(confirmed)
+        self.assertGreaterEqual(time.monotonic() - start, 0.9)
+
+    def test_survives_a_state_file_deleted_mid_wait(self):
+        target = write(self.dir / "GALE01.s08", b"partial")
+        before = {}
+        target.unlink()
+        self.assertFalse(self.wait(before, timeout=0.8))
+
+    def test_a_missing_state_dir_is_not_an_exception(self):
+        missing = Path(self.tmp.name, "gone")
+        self.assertEqual(broker._sstate_snapshot(missing), {})
+        self.assertFalse(
+            broker._wait_for_sstate_write(missing, {}, time.monotonic() + 0.3, 8)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this branch adds

The RomM in-game sync surface for the Dolphin Docker mod, plus the hardening and tests around it.

**Endpoints**
- `GET/PUT /state-file` — savestate sync per slot
- `GET/PUT /save-file` — zip of the GameCube/Wii/memory-card save trees, baseline-filtered
- `GET/PUT /memory-card` — whole GCI card sync
- `GET /state-screenshot` — savestate thumbnails
- `load_slot` on `/launch` for resume-from-state

**Hardening**
- Zip extraction is streamed and budgeted; attacker-controlled `file_size`, encrypted members, and unsupported compression methods are rejected archives, not 500s or bombs.
- Restores stage-then-commit into a dir beside the save trees, never inside them, so a crash mid-restore can't strand temp files where the next `GET /save-file` would ship them.
- A single save-tree lock serialises concurrent restores and the GET archive build, so two `PUT`s can't eat each other's staged members and a GET can't zip a tree caught mid-rename.
- Crash-relaunch backoff with a cap, launch serialisation, a real display wait, and a `/launch`-during-backoff guard.
- Uploads spool onto the mounted `/config` volume rather than the socket-only `/tmp`; stale spools are swept at boot, fallback location included.
- The streamed state pull tolerates a client hangup instead of raising an unhandled `BrokenPipeError`.

**Tests** — 207 stdlib `unittest` tests, no container, no emulator: routing/auth/status codes, zip bombs and planted symlinks, unreadable members, spooling, interrupted card swaps, crash-relaunch backoff, and a text-level drift detector between `init.sh` and `broker.py`.

## Review

The broker was taken through several rounds of adversarial review; every finding on the save-sync, spawn, and relaunch paths was fixed and pinned with a test that fails without its guard.