### PR TITLE
fix: rank every level together so a set boots disc 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,15 +92,26 @@ All `POST`/`DELETE` endpoints require `X-Broker-Secret` header if `BROKER_SECRET
 **directory**, for libraries laid out one game per folder
 (`roms/gc/Metroid Prime/Metroid Prime.iso`). RomM addresses such a game by its
 folder, because `Rom.full_path` is `fs_path/fs_name` and for a multi-file ROM
-`fs_name` is the directory, so the broker looks inside for the disc image: the
-folder itself first, then one level down for the per-disc subfolders some sets
-use. Candidates are ranked by format (`.rvz`, `.iso`, `.gcm`, `.wbfs`, `.wia`,
-`.gcz`, `.ciso`, `.tgc`, `.wad`, `.dol`, `.elf`) and then by name, so a
-multi-disc set boots disc 1 and a real disc image wins over a homebrew `.dol`
-sitting beside it. `.m3u` playlists are skipped, because Dolphin boots the disc
-itself and every folder shipping a playlist also ships the discs it points at.
-Dot-files are skipped, and a symlink pointing outside `ROM_ROOT` is never
-chosen. The resolved file is what `/status` and the response body report.
+`fs_name` is the directory, so the broker looks inside for the disc image, in
+the folder itself and one level down for the per-disc subfolders some sets use.
+Everything found across both levels is ranked together, in this order:
+
+1. **Disc number**, read from the file or folder name (`Disc 1`, `(Disc 2)`,
+   `CD1`), so a multi-disc set like RE4 starts on disc 1. The number is compared
+   as a number, which keeps disc 2 ahead of disc 10. A name that mentions no
+   disc counts as disc 1.
+2. **Format**: `.rvz`, `.iso`, `.gcm`, `.wbfs`, `.wia`, `.gcz`, `.ciso`,
+   `.tgc`, `.wad`, `.dol`, `.elf`. This decides between two candidates for the
+   same disc, so a real disc image wins over a homebrew `.dol` beside it.
+3. **Depth**, so the image sitting in the game folder wins over one buried in
+   an extras subfolder.
+
+`.m3u` playlists are skipped, because Dolphin boots the disc itself and every
+folder shipping a playlist also ships the discs it points at. Dot-files are
+skipped, and a symlink pointing outside `ROM_ROOT` is never chosen. The resolved
+file is what `/status` and the response body report. Note that resolution only
+chooses where a session *starts*: there is no disc swapping, so a game that asks
+for its next disc cannot be given one.
 
 A directory with nothing bootable inside returns `422` with the accepted
 extensions in an `extensions` field, which is a different message from the

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -7,6 +7,7 @@ import io
 import json
 import logging
 import os
+import re
 import shutil
 import signal
 import socket as _socket
@@ -162,6 +163,23 @@ ROM_EXTENSIONS = (
 # walk of a large set, and anything further down is extras, not the game.
 _ROM_SEARCH_GLOBS = ("*", "*/*")
 
+# "Disc 1", "(Disc 2)", "CD1", "Disk_3" in a folder or file name. The leading
+# boundary keeps it off words that merely end in the letters, so "abcd2.iso" is
+# not read as disc 2.
+_DISC_RE = re.compile(r"(?:^|[^a-z0-9])(?:disc|disk|cd)[\s._-]*(\d+)", re.IGNORECASE)
+
+
+def _disc_number(rel: Path) -> int:
+    """Disc number named anywhere in `rel`, or 1 when nothing names one.
+
+    Unmarked files count as disc 1 so that a single-disc game ranks level with
+    the first disc of a set, and so a false positive can only ever mean "first".
+    """
+    match = _DISC_RE.search(str(rel))
+    if match is None:
+        return 1
+    return max(1, int(match.group(1)))
+
 
 def _resolve_rom_file(path: Path) -> Path | None:
     """Return the file Dolphin should boot for `path`, or None if there isn't
@@ -177,23 +195,35 @@ def _resolve_rom_file(path: Path) -> Path | None:
         return path
     if not path.is_dir():
         return None
+    # Every level is collected before anything is ranked. Taking the first level
+    # that merely yields a match would let an extras file with a bootable
+    # extension beat the real game one level down.
+    candidates: list[Path] = []
     for pattern in _ROM_SEARCH_GLOBS:
         try:
-            found = _pick_rom_file(path.glob(pattern))
+            candidates.extend(path.glob(pattern))
         except OSError:
             # Libraries are routinely NFS mounts, so a stalled or vanished
             # share surfaces here as an OSError mid-walk. Report it as "no
             # bootable file" rather than 500-ing the launch.
             return None
-        if found is not None:
-            return found
-    return None
+    return _pick_rom_file(candidates, path)
 
 
-def _pick_rom_file(candidates: Iterable[Path]) -> Path | None:
-    """Best bootable file among `candidates`, by format preference then name
-    (which puts 'Disc 1' ahead of 'Disc 2' for a multi-disc set)."""
-    ranked: list[tuple[int, str, Path]] = []
+def _pick_rom_file(candidates: Iterable[Path], base: Path) -> Path | None:
+    """Best bootable file among `candidates`, all of them somewhere under `base`.
+
+    Ranked by disc number, then format, then depth, then name:
+
+      * disc first, so a set starts on disc 1 whatever format the later discs
+        are in. Comparing the numbers also keeps 'Disc 2' ahead of 'Disc 10',
+        which sorting the names as text does not.
+      * format next, because among candidates for the same disc it decides
+        which disc image to boot.
+      * then depth, so the disc image sitting in the game folder wins over one
+        buried in an extras subfolder.
+    """
+    ranked: list[tuple[int, int, int, str, Path]] = []
     for p in candidates:
         if p.name.startswith("."):
             continue
@@ -206,14 +236,18 @@ def _pick_rom_file(candidates: Iterable[Path]) -> Path | None:
             # A symlink in the folder must not walk the launch out of
             # ROM_ROOT: _validate_rom_path only vetted the folder itself.
             real = p.resolve()
-        except OSError:
+            rel = p.relative_to(base)
+        except (OSError, ValueError):
             continue
         if not real.is_relative_to(ROM_ROOT):
             continue
-        ranked.append((ROM_EXTENSIONS.index(ext), p.name.lower(), real))
+        ranked.append(
+            (_disc_number(rel), ROM_EXTENSIONS.index(ext), len(rel.parts),
+             p.name.lower(), real)
+        )
     if not ranked:
         return None
-    return min(ranked)[2]
+    return min(ranked)[4]
 
 
 def _chown_abc(path: Path):

--- a/tests/test_rom_path.py
+++ b/tests/test_rom_path.py
@@ -124,6 +124,28 @@ class RomFileResolution(unittest.TestCase):
         self._rom("gc/RE4/Disc 2/RE4.iso")
         self.assertEqual(broker._resolve_rom_file(self.root / "gc" / "RE4"), disc1)
 
+    def test_homebrew_executable_at_the_top_does_not_beat_a_nested_disc(self):
+        """A .dol loose in the game folder must not win just for being shallow:
+        the real discs are one level down in per-disc subfolders."""
+        disc1 = self._rom("gc/RE4/Disc 1/RE4 (Disc 1).rvz")
+        self._rom("gc/RE4/Disc 2/RE4 (Disc 2).rvz")
+        self._rom("gc/RE4/boot.dol")
+        self.assertEqual(broker._resolve_rom_file(self.root / "gc" / "RE4"), disc1)
+
+    def test_disc_one_wins_even_when_disc_two_is_a_better_format(self):
+        """Format preference decides which of two candidates for the *same*
+        disc to boot. It must not decide which disc to start on."""
+        disc1 = self._rom("gc/RE4/Disc 1/RE4.iso")
+        self._rom("gc/RE4/Disc 2/RE4.rvz")
+        self.assertEqual(broker._resolve_rom_file(self.root / "gc" / "RE4"), disc1)
+
+    def test_disc_two_beats_disc_ten(self):
+        """Disc order is numeric. Sorting the names as text puts 'Disc 10'
+        ahead of 'Disc 2', which starts a long set on the wrong disc."""
+        disc2 = self._rom("gc/Game/Game (Disc 2).iso")
+        self._rom("gc/Game/Game (Disc 10).iso")
+        self.assertEqual(broker._resolve_rom_file(self.root / "gc" / "Game"), disc2)
+
     def test_top_level_image_wins_over_a_nested_one(self):
         top = self._rom("gc/Game/Game.iso")
         self._rom("gc/Game/extras/bonus.iso")


### PR DESCRIPTION
## The bug

`_resolve_rom_file` walked the search globs one level at a time and returned the
first level that yielded *any* match, ranking within a level by format then name.
That starts a game on the wrong file in three ways:

**A stray extras file beat the real disc.** A `.bin` or `.dol` loose at the top of
the game folder won outright over the disc images in per-disc subfolders one level
down, because the shallower level was consulted first and its result returned
unconditionally. The player boots a manual instead of the game.

**Format outranked disc order.** In a set whose discs are not all the same format,
disc 2 as a `.chd` beat disc 1 as an `.iso`.

**Disc order was alphabetical.** `Disc 10` sorted ahead of `Disc 2`, so a long set
started on the wrong disc.

## The fix

Collect candidates from every level first, then rank once by
**disc number → format → depth → name**.

- **Disc number** is read off the file or folder name (`Disc 1`, `(Disc 2)`, `CD1`,
  `Disk_3`) and compared as a number. A name that mentions no disc counts as
  disc 1, which means single-disc games rank exactly as they did before and a
  regex false positive can only ever mean "first". The pattern requires a
  non-alphanumeric boundary, so `abcd2.iso` is not read as disc 2.
- **Format** still decides between candidates for the *same* disc, so a `.chd`
  beats the raw `.bin` beside it.
- **Depth** is in the key deliberately. Collapsing the levels without it would
  have lost the existing preference for the image in the game folder over one in
  an extras subfolder, which is guarded by a test that predates this change.

## Scope

Every broker shares one resolution algorithm, so this lands identically in all
five. On Switch and PS3 the disc key is inert (nothing is multi-disc, everything
defaults to 1); those repos still take it so the five copies do not drift, and
they get the cross-level ranking fix, which does apply.

## Not addressed

Resolution only chooses where a session **starts**. There is no disc swapping in
any broker: RomM sends one folder path and no disc index, so when a game asks for
its next disc there is no way to supply one. That needs changes on both sides and
is out of scope here.

## Verification

New tests were each confirmed to fail against the unfixed broker before the fix
was applied, then to pass after. Full suites and `ruff` green in all five repos.
