### PR TITLE
Persist in-app Dolphin settings and pin GLVND for NVIDIA (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,11 +173,12 @@ The broker forces these on every launch, and they cannot be overridden from Dolp
 
 | Setting | Value | Why |
 |---|---|---|
-| `GFXBackend` | `OpenGL` | Vulkan switches to Wayland WSI when `WAYLAND_DISPLAY` is set, bypassing X11 |
 | `RenderToMain` | `False` | `True` creates an unmapped render window in this build |
 | `QT_QPA_PLATFORM` | `xcb` | Without it Qt takes a broken Wayland path |
 | `WAYLAND_DISPLAY` | *(unset)* | Set, Dolphin renders straight to Wayland and X11 stays black |
 | `Fullscreen` | `True` in game, `False` on the dashboard | Stops the idle boot going black |
+
+`GFXBackend` is seeded, not forced. The broker writes `OpenGL` into a fresh config so the first boot always renders (Vulkan drives the Wayland WSI when `WAYLAND_DISPLAY` is set and black-screens the X11 stream), and inserts it if an existing config carries no backend at all. After that the choice is yours: pick a backend in Dolphin's Graphics settings and it persists across sessions like any other in-app setting. The catch is that Vulkan black-screens the stream and the choice sticks, so the next launch stays black too. Recover by deleting the `GFXBackend` line from `[Core]` in `Dolphin.ini` (the broker reseeds `OpenGL`) or setting it back to `OpenGL` by hand.
 
 ### Graphics environment
 
@@ -196,7 +197,7 @@ Main Stick/Calibration = 100.00 100.00 100.00 100.00 100.00 100.00 100.00 100.00
 C-Stick/Calibration    = 100.00 100.00 100.00 100.00 100.00 100.00 100.00 100.00
 ```
 
-Mapping and calibration live in `/config` and survive game switches. One catch: Dolphin does not save controller settings on exit, so you have to click **Close** (not just OK) in its controller dialog for changes to reach disk.
+Mapping and calibration live in `/config` and survive game switches. Because the broker quits Dolphin cleanly on teardown, changes you make in its controller dialog are flushed to disk on exit, the same way graphics settings now persist.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,11 @@ The broker forces these on every launch, and they cannot be overridden from Dolp
 | `WAYLAND_DISPLAY` | *(unset)* | Set, Dolphin renders straight to Wayland and X11 stays black |
 | `Fullscreen` | `True` in game, `False` on the dashboard | Stops the idle boot going black |
 
-`GFXBackend` is seeded, not forced. The broker writes `OpenGL` into a fresh config so the first boot always renders (Vulkan drives the Wayland WSI when `WAYLAND_DISPLAY` is set and black-screens the X11 stream), and inserts it if an existing config carries no backend at all. After that the choice is yours: pick a backend in Dolphin's Graphics settings and it persists across sessions like any other in-app setting. The catch is that Vulkan black-screens the stream and the choice sticks, so the next launch stays black too. Recover by deleting the `GFXBackend` line from `[Core]` in `Dolphin.ini` (the broker reseeds `OpenGL`) or setting it back to `OpenGL` by hand.
+`GFXBackend` is seeded, not forced. The broker writes `OpenGL` into a fresh config, and inserts it if an existing config carries no backend at all, so the first boot always renders on a backend known to be safe across GPUs rather than falling through to whatever default Dolphin picks. After that the choice is yours: pick a backend in Dolphin's Graphics settings and it persists across sessions like any other in-app setting.
+
+Vulkan was tested on the AMD (radeonsi/radv) reference host and renders to the X11 stream fine, identical to OpenGL, because the broker unsets `WAYLAND_DISPLAY` so Vulkan uses the xcb surface rather than the Wayland WSI. It has not been tested on NVIDIA, where GPU selection has its own quirks (see the GLVND note below), so OpenGL stays the seeded default. If a backend you picked ever fails to render, delete the `GFXBackend` line from `[Core]` in `Dolphin.ini` (the broker reseeds `OpenGL`) or set it back to `OpenGL` by hand.
+
+Note that changing `GFXBackend` by editing `Dolphin.ini` while Dolphin is running has no effect: on the next launch the broker quits the live instance cleanly, which flushes its in-memory backend back over your edit before the seed patch runs. Change the backend from Dolphin's own Graphics settings instead, which is what persistence is built around.
 
 ### Graphics environment
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ The broker forces these on every launch, and they cannot be overridden from Dolp
 | `WAYLAND_DISPLAY` | *(unset)* | Set, Dolphin renders straight to Wayland and X11 stays black |
 | `Fullscreen` | `True` in game, `False` on the dashboard | Stops the idle boot going black |
 
+### Graphics environment
+
+`sudo` resets the environment before launching Dolphin, so the broker forwards graphics variables through explicitly. Anything the operator sets on the container in the vendor namespaces (`NVIDIA_*`, `VK_*`, `MESA_*`, `LIBGL_*`, `GALLIUM_*`, `RADV_*`, `AMD_*`, `DRI_*`, `LIBVA_*`, `VDPAU_*`, `__GLX_*`, `__NV_*`, `__EGL_*`, `__VK_*`), plus `XDG_DATA_DIRS` and the base image's `DRINODE`, reaches Dolphin. Empty values are dropped rather than forwarded as blanks.
+
+On an NVIDIA host the broker also pins `__GLX_VENDOR_LIBRARY_NAME=nvidia` (and the NVIDIA EGL ICD when its file is present) so GL vendor selection does not depend on udev. The gamepad interposer's fake libudev hides the NVIDIA device from GLVND's udev lookup, which otherwise drops the renderer to Mesa's `llvmpipe`; Mesa-native drivers (AMD/Intel) have a direct render-node fallback and are left alone. A value the operator set themselves always wins.
+
 ## Controllers
 
 Browser gamepad input reaches the container through the [selkies joystick interposer](https://github.com/selkies-project/selkies-gstreamer) as virtual Xbox 360 pads (`SDL/0-3/Microsoft X-Box 360 pad`). All four GCPad ports are mapped to it on first launch, seeded from `/defaults/GCPadNew.ini` only when no config exists, so your own mappings are never overwritten.

--- a/README.md
+++ b/README.md
@@ -169,18 +169,18 @@ Dolphin savestates carry no embedded frame, so the broker takes one: the screens
 
 ### Display settings
 
-The broker forces these on every launch, and they cannot be overridden from Dolphin's GUI. They exist because selkies captures X11, and Dolphin will happily bypass X11 given the chance.
+The broker forces these on every launch, and they cannot be overridden from Dolphin's GUI. They exist because selkies only captures the X11 display, so anything that could pull Dolphin's output onto a different display path is closed off.
 
 | Setting | Value | Why |
 |---|---|---|
 | `RenderToMain` | `False` | `True` creates an unmapped render window in this build |
 | `QT_QPA_PLATFORM` | `xcb` | Without it Qt takes a broken Wayland path |
-| `WAYLAND_DISPLAY` | *(unset)* | Set, Dolphin renders straight to Wayland and X11 stays black |
+| `WAYLAND_DISPLAY` | *(unset)* | Stripped as a precaution so Dolphin stays on the X11 render path selkies captures; the "if set" behavior is unverified |
 | `Fullscreen` | `True` in game, `False` on the dashboard | Stops the idle boot going black |
 
 `GFXBackend` is seeded, not forced. The broker writes `OpenGL` into a fresh config, and inserts it if an existing config carries no backend at all, so the first boot always renders on a backend known to be safe across GPUs rather than falling through to whatever default Dolphin picks. After that the choice is yours: pick a backend in Dolphin's Graphics settings and it persists across sessions like any other in-app setting.
 
-Vulkan was tested on the AMD (radeonsi/radv) reference host and renders to the X11 stream fine, identical to OpenGL, because the broker unsets `WAYLAND_DISPLAY` so Vulkan uses the xcb surface rather than the Wayland WSI. It has not been tested on NVIDIA, where GPU selection has its own quirks (see the GLVND note below), so OpenGL stays the seeded default. If a backend you picked ever fails to render, delete the `GFXBackend` line from `[Core]` in `Dolphin.ini` (the broker reseeds `OpenGL`) or set it back to `OpenGL` by hand.
+Vulkan was tested on the AMD (radeonsi/radv) reference host and renders to the X11 stream fine, identical to OpenGL. It has not been tested on NVIDIA, where GPU selection has its own quirks (see the GLVND note below), so OpenGL stays the seeded default. If a backend you picked ever fails to render, delete the `GFXBackend` line from `[Core]` in `Dolphin.ini` (the broker reseeds `OpenGL`) or set it back to `OpenGL` by hand.
 
 Note that changing `GFXBackend` by editing `Dolphin.ini` while Dolphin is running has no effect: on the next launch the broker quits the live instance cleanly, which flushes its in-memory backend back over your edit before the seed patch runs. Change the backend from Dolphin's own Graphics settings instead, which is what persistence is built around.
 

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -498,8 +498,42 @@ def _patch_ini(fullscreen: bool = False):
             pass
 
 
+QUIT_WAIT = float(os.environ.get("QUIT_WAIT", "6.0"))
+
+
+def _graceful_quit(proc, timeout: float = QUIT_WAIT) -> bool:
+    """Ask Dolphin to close itself so it flushes its own config to disk.
+
+    While a game is running Dolphin keeps GUI graphics changes (aspect ratio,
+    internal resolution, and the rest of GFX.ini) in a runtime config layer and
+    only writes them out on a clean Qt shutdown. A group SIGTERM skips that
+    flush, so anything the player changed in the Graphics dialog is discarded on
+    the next launch. Sending Alt+F4 to the window drives the clean-close path
+    instead; ConfirmStop=False (pinned in Dolphin.ini) means it exits without a
+    "Stop emulation?" prompt. Returns True if Dolphin exited on its own within
+    the timeout, False if it now has to be signalled.
+    """
+    wid = _xdotool_find_window()
+    if wid is None:
+        return False
+    if not _xdotool_key(wid, "alt+F4"):
+        return False
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            log.info("Dolphin quit cleanly on Alt+F4 (config flushed)")
+            return True
+        time.sleep(0.2)
+    log.warning("Dolphin did not quit within %.1fs of Alt+F4: falling back to signals", timeout)
+    return False
+
+
 def _kill_dolphin():
-    """Kill the managed dolphin-emu process group."""
+    """Stop the managed dolphin-emu process.
+
+    Tries a graceful Alt+F4 quit first so Dolphin persists its own config
+    (see _graceful_quit), then falls back to a group SIGTERM/SIGKILL.
+    """
     with _session_lock:
         _session["is_managed"] = False
         proc = _session["process"]
@@ -512,6 +546,8 @@ def _kill_dolphin():
         return
 
     log.info("Stopping Dolphin (PID %d)...", proc.pid)
+    if _graceful_quit(proc):
+        return
     try:
         pgid = os.getpgid(proc.pid)
         os.killpg(pgid, signal.SIGTERM)

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -436,13 +436,15 @@ def _patch_ini(fullscreen: bool = False):
         },
     }
 
-    # Forced once, then left to the player. OpenGL is written into a fresh
-    # config so the first boot is guaranteed to render (Vulkan grabs the Wayland
-    # surface and black-screens the stream), and inserted if a pre-existing
-    # Dolphin.ini carries no backend at all so it cannot fall through to
-    # Dolphin's own default. Once the key is present it is never rewritten, so a
-    # backend the player picks in Dolphin's Graphics settings persists across
-    # sessions like every other in-app setting.
+    # Seeded once, then left to the player. OpenGL is written into a fresh
+    # config, and inserted if a pre-existing Dolphin.ini carries no backend at
+    # all, so the first boot lands on a backend known to be safe across GPUs
+    # rather than falling through to Dolphin's own default. Once the key is
+    # present it is never rewritten, so a backend the player picks in Dolphin's
+    # Graphics settings persists across sessions like every other in-app setting.
+    # OpenGL is the seed, not Vulkan, only because Vulkan is unverified on NVIDIA
+    # here; on the AMD reference host Vulkan renders to the X11 stream fine (the
+    # broker unsets WAYLAND_DISPLAY, so it uses the xcb surface, not Wayland).
     seed = {
         "Core": {"GFXBackend": "OpenGL"},
     }

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -131,11 +131,14 @@ ENV = {
     **_gpu,
     **_glvnd_env(_gpu),
     "DISPLAY":            ":0",
-    # WAYLAND_DISPLAY intentionally omitted: if set, Dolphin's Vulkan backend
-    # creates a VK_KHR_wayland_surface and renders directly to the Wayland
-    # compositor, leaving the X11 window black.  Without it, Vulkan uses
-    # VK_KHR_xcb_surface and renders into the X11 window that Xwayland
-    # composites into labwc, which is what selkies captures.
+    # WAYLAND_DISPLAY intentionally omitted as a precaution: with it unset,
+    # Vulkan uses VK_KHR_xcb_surface and renders into the X11 window that
+    # Xwayland composites into labwc, which is what selkies captures (verified
+    # on the AMD reference host, identical to OpenGL). The concern with setting
+    # it is that Dolphin's Vulkan backend could bind a VK_KHR_wayland_surface
+    # instead and leave the X11 window black, but that has not been tested here
+    # and QT_QPA_PLATFORM=xcb already forces the render window to X11, so it is
+    # kept unset rather than relied upon either way.
     "XDG_RUNTIME_DIR":    "/config/.XDG",
     "QT_QPA_PLATFORM":    "xcb",
     "PULSE_RUNTIME_PATH": "/defaults",

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -424,7 +424,6 @@ def _patch_ini(fullscreen: bool = False):
             "SIDevice1": "0",
             "SIDevice2": "0",
             "SIDevice3": "0",
-            "GFXBackend": "OpenGL",
             "CPUThread": "False",
             "SlotA": str(EXI_MEMORY_CARD_FOLDER),
             "GCIFolderAPathOverride": card_dir,
@@ -437,11 +436,26 @@ def _patch_ini(fullscreen: bool = False):
         },
     }
 
+    # Forced once, then left to the player. OpenGL is written into a fresh
+    # config so the first boot is guaranteed to render (Vulkan grabs the Wayland
+    # surface and black-screens the stream), and inserted if a pre-existing
+    # Dolphin.ini carries no backend at all so it cannot fall through to
+    # Dolphin's own default. Once the key is present it is never rewritten, so a
+    # backend the player picks in Dolphin's Graphics settings persists across
+    # sessions like every other in-app setting.
+    seed = {
+        "Core": {"GFXBackend": "OpenGL"},
+    }
+
     try:
         lines = INI_PATH.read_text().splitlines()
         current_section: str | None = None
         applied: dict[str, set] = {s: set() for s in target}
+        seed_present: dict[str, set] = {s: set() for s in seed}
         new_lines = []
+
+        def _key_here(stripped: str, key: str) -> bool:
+            return stripped.startswith(f"{key} =") or stripped.startswith(f"{key}=")
 
         for line in lines:
             stripped = line.strip()
@@ -450,9 +464,16 @@ def _patch_ini(fullscreen: bool = False):
                 new_lines.append(line)
                 continue
 
+            # Record a seed key already in the file so it is neither reinserted
+            # nor overwritten: whatever the player set is left exactly as is.
+            if current_section in seed:
+                for key in seed[current_section]:
+                    if _key_here(stripped, key):
+                        seed_present[current_section].add(key)
+
             if current_section in target:
                 for key, val in target[current_section].items():
-                    if stripped.startswith(f"{key} =") or stripped.startswith(f"{key}="):
+                    if _key_here(stripped, key):
                         new_lines.append(f"{key} = {val}")
                         applied[current_section].add(key)
                         break
@@ -464,22 +485,31 @@ def _patch_ini(fullscreen: bool = False):
         # Insert missing keys under their existing section header; only create
         # the section if the file doesn't have it at all. Blindly appending a
         # second [section] block at EOF accumulates duplicate headers.
-        for section, keys in target.items():
-            missing = {k: v for k, v in keys.items() if k not in applied[section]}
-            if not missing:
-                continue
+        def _insert(section: str, kv: dict[str, str]) -> None:
+            if not kv:
+                return
             header_idx = next(
                 (i for i, line in enumerate(new_lines) if line.strip() == f"[{section}]"),
                 None,
             )
-            add_lines = [f"{k} = {v}" for k, v in missing.items()]
+            add_lines = [f"{k} = {v}" for k, v in kv.items()]
             if header_idx is None:
                 new_lines.append(f"[{section}]")
                 new_lines.extend(add_lines)
             else:
                 new_lines[header_idx + 1:header_idx + 1] = add_lines
+
+        for section, keys in target.items():
+            missing = {k: v for k, v in keys.items() if k not in applied[section]}
+            _insert(section, missing)
             for k in missing:
                 log.warning("Dolphin.ini: [%s] %s not found, inserted", section, k)
+
+        for section, keys in seed.items():
+            missing = {k: v for k, v in keys.items() if k not in seed_present[section]}
+            _insert(section, missing)
+            for k in missing:
+                log.info("Dolphin.ini: seeded [%s] %s once, kept thereafter", section, k)
 
         tmp = INI_PATH.with_suffix(".tmp")
         tmp.write_text("\n".join(new_lines) + "\n")

--- a/root/root/broker.py
+++ b/root/root/broker.py
@@ -93,9 +93,43 @@ def _gpu_env() -> dict[str, str]:
     }
 
 
+def _nvidia_present() -> bool:
+    """True when an NVIDIA GPU is passed into the container."""
+    return Path("/dev/nvidiactl").exists() or Path("/dev/nvidia0").exists()
+
+
+# The NVIDIA EGL ICD, present only when the NVIDIA userspace is installed. It is
+# the ICD the loader would otherwise have to find by udev device correlation,
+# which is the step the fake libudev breaks.
+_NVIDIA_EGL_ICD = Path("/usr/share/glvnd/egl_vendor.d/10_nvidia.json")
+
+
+def _glvnd_env(already_set: dict) -> dict:
+    """Pin GLVND to the NVIDIA vendor so GL selection does not consult udev.
+
+    On NVIDIA the fake libudev (loaded for the gamepad interposer) advertises no
+    NVIDIA device, so GLVND cannot correlate the DRM node and falls back to Mesa
+    swrast (llvmpipe). Naming the vendor outright skips that lookup entirely.
+    Skipped on non-NVIDIA hosts, where forcing the nvidia vendor would break a
+    working Mesa driver, and never overrides a value the operator set."""
+    if not _nvidia_present():
+        return {}
+    env = {}
+    if "__GLX_VENDOR_LIBRARY_NAME" not in already_set:
+        env["__GLX_VENDOR_LIBRARY_NAME"] = "nvidia"
+    # Only pin the EGL ICD when its file is actually there: pointing the loader
+    # at a missing filename disables every other ICD and breaks EGL outright.
+    if "__EGL_VENDOR_LIBRARY_FILENAMES" not in already_set and _NVIDIA_EGL_ICD.exists():
+        env["__EGL_VENDOR_LIBRARY_FILENAMES"] = str(_NVIDIA_EGL_ICD)
+    return env
+
+
+_gpu = _gpu_env()
 ENV = {
-    # Inherited GPU vars come first so the explicit entries below always win.
-    **_gpu_env(),
+    # Operator GPU knobs first, then our NVIDIA GLVND defaults for the names the
+    # operator did not set, then the fixed entries below, which always win.
+    **_gpu,
+    **_glvnd_env(_gpu),
     "DISPLAY":            ":0",
     # WAYLAND_DISPLAY intentionally omitted: if set, Dolphin's Vulkan backend
     # creates a VK_KHR_wayland_surface and renders directly to the Wayland
@@ -148,6 +182,8 @@ else:
         "ICD was never injected (check NVIDIA_DRIVER_CAPABILITIES includes 'graphics'); "
         "NVIDIA present means the failure is at surface creation instead."
     )
+if _nvidia_present():
+    log.info("NVIDIA GPU detected; pinned GLVND vendor so GL selection skips udev.")
 
 # ── Session state ─────────────────────────────────────────────────────────────
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,6 +22,7 @@ dir through the `SSTATE_DIR`, `SAVE_DATA_ROOT` and `GCI_CARD_DIR` overrides.
 | `test_hardening.py` | Zip bombs, planted symlinks, unreadable members, spooling, interrupted card swaps |
 | `test_process_lifecycle.py` | Crash-relaunch backoff and cap, launch serialisation, the display wait |
 | `test_audio_sinks.py` | Recreating the null sinks svc-selkies drops, and where the default sink points |
+| `test_gpu_env.py` | Graphics-env forwarding through the sudo hop and the NVIDIA GLVND pin |
 | `test_packaging.py` | s6 wiring, sudoers coverage, and drift between `init.sh` and `broker.py` |
 
 `test_packaging.py` is the early-warning half. It reads `broker.py` and

--- a/tests/test_gpu_env.py
+++ b/tests/test_gpu_env.py
@@ -7,6 +7,8 @@ from the outside like the container ignoring its own configuration.
 """
 
 import os
+import pathlib
+import tempfile
 import unittest
 import unittest.mock as mock
 
@@ -63,6 +65,45 @@ class GpuEnvTests(unittest.TestCase):
         an inherited value must not undo either."""
         self.assertEqual(broker.ENV["DISPLAY"], ":0")
         self.assertNotIn("WAYLAND_DISPLAY", broker.ENV)
+
+
+class GlvndPin(unittest.TestCase):
+    """Issue #7: the gamepad interposer's fake libudev hides the NVIDIA device
+    from GLVND's udev lookup, dropping the renderer to llvmpipe. Naming the
+    vendor outright is the fix, but only on NVIDIA and never over an operator's
+    own choice."""
+
+    def test_nothing_is_pinned_off_nvidia(self):
+        # Forcing the nvidia vendor on an AMD/Intel host would break a working
+        # Mesa driver, which is exactly the platform where the fake libudev is
+        # already harmless.
+        with mock.patch.object(broker, "_nvidia_present", lambda: False):
+            self.assertEqual(broker._glvnd_env({}), {})
+
+    def test_the_glx_vendor_is_pinned_on_nvidia(self):
+        with mock.patch.object(broker, "_nvidia_present", lambda: True), \
+             mock.patch.object(broker, "_NVIDIA_EGL_ICD", pathlib.Path("/nope.json")):
+            self.assertEqual(
+                broker._glvnd_env({}), {"__GLX_VENDOR_LIBRARY_NAME": "nvidia"}
+            )
+
+    def test_an_operator_vendor_choice_is_never_overridden(self):
+        with mock.patch.object(broker, "_nvidia_present", lambda: True), \
+             mock.patch.object(broker, "_NVIDIA_EGL_ICD", pathlib.Path("/nope.json")):
+            self.assertEqual(
+                broker._glvnd_env({"__GLX_VENDOR_LIBRARY_NAME": "mesa"}), {}
+            )
+
+    def test_the_egl_icd_is_pinned_only_when_its_file_exists(self):
+        # Pointing the loader at a missing filename disables every other ICD and
+        # breaks EGL outright, so the pin is conditional on the file being there.
+        with mock.patch.object(broker, "_nvidia_present", lambda: True):
+            with tempfile.NamedTemporaryFile(suffix=".json") as f:
+                with mock.patch.object(broker, "_NVIDIA_EGL_ICD", pathlib.Path(f.name)):
+                    self.assertEqual(
+                        broker._glvnd_env({}).get("__EGL_VENDOR_LIBRARY_FILENAMES"),
+                        f.name,
+                    )
 
 
 if __name__ == "__main__":

--- a/tests/test_ini_patch.py
+++ b/tests/test_ini_patch.py
@@ -105,8 +105,8 @@ class IniPatch(unittest.TestCase):
     # ── the backend is seeded once, then owned by the player ──────────────
 
     def test_a_fresh_config_is_seeded_with_opengl(self):
-        # OpenGL guarantees the first boot renders; Vulkan black-screens the
-        # Wayland stream.
+        # OpenGL is the backend known safe across GPUs, so a fresh config boots
+        # on it rather than falling through to Dolphin's own default.
         broker._patch_ini()
         self.assertEqual(parse_ini(self.read())["Core"]["GFXBackend"], "OpenGL")
 

--- a/tests/test_ini_patch.py
+++ b/tests/test_ini_patch.py
@@ -94,14 +94,48 @@ class IniPatch(unittest.TestCase):
     def test_overwrites_existing_wrong_values(self):
         self.ini.parent.mkdir(parents=True)
         self.ini.write_text(
-            "[Core]\nGFXBackend = Vulkan\nCPUThread = True\n"
+            "[Core]\nCPUThread = True\n"
             "[Interface]\nConfirmStop = True\n"
         )
         broker._patch_ini()
         cfg = parse_ini(self.read())
-        self.assertEqual(cfg["Core"]["GFXBackend"], "OpenGL")
         self.assertEqual(cfg["Core"]["CPUThread"], "False")
         self.assertEqual(cfg["Interface"]["ConfirmStop"], "False")
+
+    # ── the backend is seeded once, then owned by the player ──────────────
+
+    def test_a_fresh_config_is_seeded_with_opengl(self):
+        # OpenGL guarantees the first boot renders; Vulkan black-screens the
+        # Wayland stream.
+        broker._patch_ini()
+        self.assertEqual(parse_ini(self.read())["Core"]["GFXBackend"], "OpenGL")
+
+    def test_a_backend_the_player_picked_is_not_reset(self):
+        # The whole point of the change: a value chosen in Dolphin's Graphics
+        # settings must survive the next launch's ini patch.
+        self.ini.parent.mkdir(parents=True)
+        self.ini.write_text("[Core]\nGFXBackend = Vulkan\nCPUThread = True\n")
+        broker._patch_ini()
+        cfg = parse_ini(self.read())
+        self.assertEqual(cfg["Core"]["GFXBackend"], "Vulkan")
+        self.assertEqual(cfg["Core"]["CPUThread"], "False")  # still forced
+
+    def test_a_pre_existing_config_without_a_backend_is_seeded(self):
+        # An older Dolphin.ini with no GFXBackend must not fall through to
+        # Dolphin's own default, which may be Vulkan.
+        self.ini.parent.mkdir(parents=True)
+        self.ini.write_text("[Core]\nCPUThread = True\n")
+        broker._patch_ini()
+        self.assertEqual(parse_ini(self.read())["Core"]["GFXBackend"], "OpenGL")
+
+    def test_the_backend_is_never_duplicated_across_launches(self):
+        broker._patch_ini()
+        for _ in range(3):
+            broker._patch_ini()
+        core_backends = [
+            ln for ln in self.read().splitlines() if ln.strip().startswith("GFXBackend")
+        ]
+        self.assertEqual(len(core_backends), 1, core_backends)
 
     def test_preserves_unrelated_keys(self):
         self.ini.parent.mkdir(parents=True)

--- a/tests/test_process_lifecycle.py
+++ b/tests/test_process_lifecycle.py
@@ -114,6 +114,102 @@ class CrashRelaunch(unittest.TestCase):
         self.assertEqual(self.relaunches, 0)
 
 
+class KillProc:
+    """A Popen stand-in with a scriptable poll() and wait()."""
+
+    def __init__(self, pid=4242, poll_returns=None, wait_timeouts=0):
+        self.pid = pid
+        self._poll = list(poll_returns) if poll_returns else [None]
+        self._wait_timeouts = wait_timeouts  # leading wait() calls that time out
+        self.waits = []
+
+    def poll(self):
+        return self._poll.pop(0) if len(self._poll) > 1 else self._poll[0]
+
+    def wait(self, timeout=None):
+        self.waits.append(timeout)
+        if self._wait_timeouts > 0:
+            self._wait_timeouts -= 1
+            raise broker.subprocess.TimeoutExpired(cmd="dolphin", timeout=timeout)
+        return 0
+
+
+class GracefulQuit(unittest.TestCase):
+    """Dolphin only flushes GUI graphics changes to GFX.ini on a clean Qt
+    shutdown; a group SIGTERM discards them. Teardown asks for the clean quit
+    first and only signals if that is ignored."""
+
+    def test_alt_f4_is_sent_and_a_clean_exit_skips_the_signal(self):
+        proc = KillProc(poll_returns=[0])  # already down by the first poll
+        sent = []
+        with unittest.mock.patch.object(broker, "_xdotool_find_window", lambda: "42"), \
+             unittest.mock.patch.object(broker, "_xdotool_key",
+                                        lambda wid, key: sent.append((wid, key)) or True):
+            self.assertTrue(broker._graceful_quit(proc, timeout=2))
+        self.assertEqual(sent, [("42", "alt+F4")])
+
+    def test_no_window_means_no_graceful_quit(self):
+        called = []
+        with unittest.mock.patch.object(broker, "_xdotool_find_window", lambda: None), \
+             unittest.mock.patch.object(broker, "_xdotool_key",
+                                        lambda *a: called.append(a) or True):
+            self.assertFalse(broker._graceful_quit(KillProc(), timeout=2))
+        self.assertEqual(called, [])  # never tried to send a key
+
+    def test_a_process_that_ignores_alt_f4_reports_failure(self):
+        clock = iter([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
+        proc = KillProc(poll_returns=[None])  # never exits on its own
+        with unittest.mock.patch.object(broker, "_xdotool_find_window", lambda: "42"), \
+             unittest.mock.patch.object(broker, "_xdotool_key", lambda *a: True), \
+             unittest.mock.patch.object(broker.time, "sleep", lambda _s: None), \
+             unittest.mock.patch.object(broker.time, "monotonic", lambda: next(clock)):
+            self.assertFalse(broker._graceful_quit(proc, timeout=5))
+
+
+class KillDolphin(unittest.TestCase):
+    def setUp(self):
+        reset_session()
+
+    def tearDown(self):
+        reset_session()
+
+    def _install(self, proc):
+        with broker._session_lock:
+            broker._session["process"] = proc
+            broker._session["is_managed"] = True
+
+    def test_a_clean_graceful_quit_sends_no_signal(self):
+        self._install(KillProc())
+        killed = []
+        with unittest.mock.patch.object(broker, "_graceful_quit", lambda proc: True), \
+             unittest.mock.patch.object(broker.os, "killpg",
+                                        lambda *a: killed.append(a)):
+            broker._kill_dolphin()
+        self.assertEqual(killed, [])
+
+    def test_a_stubborn_process_falls_back_to_sigterm(self):
+        proc = KillProc()
+        self._install(proc)
+        killed = []
+        with unittest.mock.patch.object(broker, "_graceful_quit", lambda proc: False), \
+             unittest.mock.patch.object(broker.os, "getpgid", lambda pid: pid), \
+             unittest.mock.patch.object(broker.os, "killpg",
+                                        lambda pgid, sig: killed.append(sig)):
+            broker._kill_dolphin()
+        self.assertEqual(killed, [broker.signal.SIGTERM])
+
+    def test_a_process_surviving_sigterm_is_sigkilled(self):
+        proc = KillProc(wait_timeouts=1)  # ignores SIGTERM, then dies
+        self._install(proc)
+        killed = []
+        with unittest.mock.patch.object(broker, "_graceful_quit", lambda proc: False), \
+             unittest.mock.patch.object(broker.os, "getpgid", lambda pid: pid), \
+             unittest.mock.patch.object(broker.os, "killpg",
+                                        lambda pgid, sig: killed.append(sig)):
+            broker._kill_dolphin()
+        self.assertEqual(killed, [broker.signal.SIGTERM, broker.signal.SIGKILL])
+
+
 class LaunchSerialisation(unittest.TestCase):
     def test_launches_do_not_interleave(self):
         # Two concurrent /launch requests used to interleave their


### PR DESCRIPTION
## Highlights

### In-app settings now persist after you change them in the UI

Dolphin only flushes its graphics and controller settings to disk on a clean Qt shutdown. The broker used to tear Dolphin down with a group SIGTERM, which skips that flush, so anything a player changed in Dolphin's own menus was discarded on the next launch.

Teardown now sends Alt+F4 first and waits for a clean exit before falling back to signals (`74de6fe`), so changes made in the Dolphin UI survive across sessions.

- Graphics settings persistence is verified live: an in-app aspect-ratio change flushed to `GFX.ini` on a clean quit where SIGTERM never did.
- Controller mappings ride the same clean-exit flush path, so this also addresses the Discord report that controller settings were not saving.
- `GFXBackend` is now seeded once instead of forced every launch (`bb7d888`), so a backend picked in Dolphin's Graphics settings sticks like any other in-app setting.

### Issue #7: NVIDIA renders with llvmpipe (proposed fix)

On NVIDIA the LD_PRELOAD fake libudev breaks GLVND vendor selection, so GL falls back to Mesa llvmpipe (CPU) even though the container's GPU access is healthy. The broker now pins the NVIDIA GLVND vendor and EGL ICD so GL vendor selection no longer depends on udev, and forwards the operator's GPU environment through the sudo hop (`64c4520`, `745e361`).

This is a proposed fix, not yet confirmed on NVIDIA hardware: the reference test host is AMD, where the fake libudev is harmless and cannot reproduce #7. The RTX 3060 reporter offered to test. In the meantime the settings-persistence work above gives affected users a manual path, since a backend chosen in the Dolphin UI now persists.

## Also included since main

This branch is 44 commits ahead of main, so the merge brings more than the above:

- #6: rank every level together so a multi-disc set boots disc 1
- #5: README rewritten around what the broker actually does
- #4: boot the disc image inside a folder-organized ROM
- a stdlib-only test suite (audio sinks, GPU env, hardening, HTTP API, ini patch, process lifecycle, ROM path, save sync, state files, memory card)
- save-state, save-file, and memory-card sync endpoints, plus process-lifecycle hardening
